### PR TITLE
Reframe Victor as agentic AI framework with correct counts

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,51 +1,127 @@
-# Victor Architecture (Overview)
+# Victor Architecture
 
-## System view
+## System View
 
+```mermaid
+flowchart TB
+    subgraph Clients["CLIENTS"]
+        CLI["CLI / TUI"]
+        HTTP["HTTP API"]
+        MCP["MCP Server"]
+        VSCODE["VS Code"]
+    end
+
+    subgraph Framework["FRAMEWORK"]
+        AGENT["Agent API"]
+        SG["StateGraph"]
+        WE["WorkflowEngine"]
+    end
+
+    subgraph Orchestrator["ORCHESTRATOR"]
+        ORC["AgentOrchestrator"]
+        CC["ConversationController"]
+        TP["ToolPipeline"]
+        PM["ProviderManager"]
+    end
+
+    subgraph Providers["PROVIDERS (22)"]
+        ANT["Anthropic"]
+        OAI["OpenAI"]
+        GGL["Google"]
+        OLL["Ollama"]
+        MORE["+ 18 more"]
+    end
+
+    subgraph Tools["TOOLS (33 modules)"]
+        FILE["File Ops"]
+        GIT["Git"]
+        EXEC["Execution"]
+        WEB["Web / Search"]
+    end
+
+    subgraph Teams["TEAMS"]
+        SEQ["Sequential"]
+        PAR["Parallel"]
+        HIER["Hierarchical"]
+        PIPE["Pipeline"]
+    end
+
+    subgraph State["STATE"]
+        WF["Workflow"]
+        CONV["Conversation"]
+        TEAM["Team"]
+        GLOB["Global"]
+    end
+
+    subgraph Verticals["VERTICALS (9)"]
+        COD["Coding"]
+        DEV["DevOps"]
+        RAG["RAG"]
+        DATA["Data Analysis"]
+        RES["Research"]
+        SEC["Security"]
+        IAC["IaC"]
+        CLS["Classification"]
+        BEN["Benchmark"]
+    end
+
+    Clients --> Framework
+    Framework --> Orchestrator
+    Orchestrator --> Providers
+    Orchestrator --> Tools
+    Orchestrator --> Teams
+    Orchestrator --> State
+    Orchestrator --> Verticals
+
+    style Clients fill:#e0e7ff,stroke:#4f46e5
+    style Framework fill:#dbeafe,stroke:#3b82f6
+    style Orchestrator fill:#d1fae5,stroke:#10b981
+    style Providers fill:#fef3c7,stroke:#f59e0b
+    style Tools fill:#cffafe,stroke:#06b6d4
+    style Teams fill:#e0e7ff,stroke:#6366f1
+    style State fill:#f3e8ff,stroke:#a855f7
+    style Verticals fill:#fce7f3,stroke:#ec4899
 ```
-User
-  -> CLI/TUI/API
-  -> Agent Orchestrator
-  -> Provider Adapter (local or cloud)
-  -> Tooling + Workflows
-  -> Storage (sessions, profiles, embeddings)
-```
 
-## Core components
+## Core Components
 
-| Component | Responsibility | Primary entry points |
-|-----------|----------------|----------------------|
-| **Agent** | Public API for chat/run/stream | `victor/framework/agent.py` |
-| **AgentOrchestrator** | Conversation loop and tool routing | `victor/agent/orchestrator.py` |
-| **Providers** | LLM I/O, auth, retry, streaming | `victor/providers/` |
-| **Tooling** | File, git, test, search, web tools | `victor/framework/tools.py` |
-| **Workflow Engine** | YAML/graph workflows | `victor/framework/workflow_engine.py` |
-| **StateGraph** | Execution runtime for workflows | `victor/framework/graph.py` |
-| **Verticals** | Domain presets (coding, RAG, etc.) | `victor/verticals/` |
-| **UI** | CLI/TUI and API server | `victor/ui/`, `victor/server/` |
+| Component | Responsibility | Entry Point |
+|-----------|----------------|-------------|
+| **Agent** | Public API: `run()`, `stream()`, `chat()`, `run_workflow()`, `run_team()` | `victor/framework/agent.py` |
+| **AgentOrchestrator** | Conversation loop, tool routing, provider calls | `victor/agent/orchestrator.py` |
+| **Providers** | LLM I/O, auth, retry, streaming (22 backends) | `victor/providers/` |
+| **Tools** | 33 tool modules across 9 categories | `victor/framework/tools.py` |
+| **StateGraph** | Typed-state execution engine with checkpointing | `victor/framework/graph.py` |
+| **WorkflowEngine** | YAML-to-StateGraph compiler | `victor/framework/workflow_engine.py` |
+| **Teams** | Multi-agent coordination (4 formations) | `victor/teams/` |
+| **State** | 4-scope state management (workflow/conversation/team/global) | `victor/state/` |
+| **Events/CQRS** | Event sourcing, CommandBus, QueryBus, middleware | `victor/core/` |
+| **Evaluation** | Agent harnesses, code quality, SWE-bench | `victor/evaluation/` |
+| **Verticals** | 9 domain-specific application bundles | `victor/verticals/` |
+| **UI** | CLI (Typer), TUI (Textual), 22 subcommands | `victor/ui/` |
 
-## Data flows
+## Data Flows
 
-**Single-agent run**
-1. User prompt enters CLI/TUI/API.
-2. Orchestrator calls provider, handles tool calls, updates state.
-3. Tools execute; results feed back into the loop.
-4. Final response returns to the user.
+**Single-agent:** User prompt → Orchestrator → Provider → Tool calls (loop) → Response
 
-**Workflow execution**
-1. Workflow YAML compiled to a StateGraph.
-2. Nodes run in order with state transitions.
-3. Outputs are merged and returned.
+**Workflow:** YAML → UnifiedCompiler → StateGraph → Node execution with state transitions → Merged output
 
-## Extension points
+**Multi-agent team:** Team spec → Formation strategy → Agent spawning → Result aggregation → Unified response
 
-- **Providers**: add LLM backends via provider adapters.
-- **Tools**: register new tool categories and implementations.
-- **Verticals**: bundle tools, prompts, and workflows.
-- **Workflows**: author YAML or programmatic graphs.
+## Extension Points
 
-## Design principles
+- **Providers** — `BaseProvider` subclass + `ProviderRegistry.register()`
+- **Tools** — `BaseTool` subclass in `victor/tools/`
+- **Verticals** — `VerticalBase` subclass; external via `victor.verticals` entry point
+- **Workflows** — YAML DSL or programmatic `StateGraph` construction
+- **Middleware** — Pre/post hooks, safety checks, rate limiting
 
-- Clear separation of orchestration, provider I/O, and tooling.
-- Provider-independent context management.
-- Opt-in complexity: workflows and teams when needed.
+## Design Principles
+
+| Principle | How |
+|-----------|-----|
+| **Facade pattern** | Orchestrator is a thin coordinator; all logic in extracted components |
+| **Protocol-based interfaces** | Python Protocols for ISP compliance (`SubAgentContext`, `CapabilityRegistry`) |
+| **Provider agnosticism** | 22 backends behind a unified interface; switch mid-conversation |
+| **Opt-in complexity** | Simple `agent.run()` by default; workflows, teams, CQRS when needed |
+| **Air-gapped capable** | Full functionality with local models (Ollama, LM Studio, vLLM) |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Dead Code Pruning** - Removed unused code from graph stores and chunker modules
 - **Backward Compatibility Aliases** - Migrated to canonical names across codebase
 
+## [0.5.3] - 2026-02-15
+
+### Changed
+- **Identity Reframe** - Victor is now described as an "agentic AI framework" across all documentation (was "coding assistant")
+- **Correct Capability Counts** - Fixed counts across 36+ files: 22 providers (was 21), 33 tool modules (was 55+), 9 verticals (was 5-6)
+- **Single-Source Versioning** - `__version__` now reads from `pyproject.toml` via `importlib.metadata`, eliminating version drift
+- **Architecture Diagrams** - Added Teams, State, Events/CQRS, Evaluation subsystems to all architecture diagrams
+
+### Fixed
+- **Cohere Provider Reference** - Removed non-existent standalone Cohere provider from README and provider comparison docs
+- **Lint Errors** - Fixed pre-existing F541, F821, F841 ruff violations in `chat.py` and `provider-features.py`
+
+## [0.5.2] - 2026-02-13
+
+### Fixed
+- **Security** - Updated Trivy to use latest vulnerability database
+- **Dependencies** - Updated aiohttp from 3.13.2 to 3.13.3
+
 ## [0.4.0] - 2026-01-03
 
 ### Added

--- a/FAQ.md
+++ b/FAQ.md
@@ -1,6 +1,6 @@
 # Frequently Asked Questions
 
-Comprehensive FAQ for Victor AI Coding Assistant. Last updated: January 2026
+Comprehensive FAQ for Victor — agentic AI framework. Last updated: February 2026
 
 ## Table of Contents
 
@@ -17,19 +17,19 @@ Comprehensive FAQ for Victor AI Coding Assistant. Last updated: January 2026
 
 ### What is Victor?
 
-**Victor** is an open-source, provider-agnostic AI coding assistant that supports 21 LLM providers (both local and cloud) through a unified CLI/TUI interface. Unlike ChatGPT or Claude's web interfaces, Victor:
+**Victor** is an open-source agentic AI framework that supports 22 LLM providers (both local and cloud) through a unified CLI/TUI interface. Unlike ChatGPT or Claude's web interfaces, Victor:
 
 - **Works offline** with local models (Ollama, LM Studio, vLLM)
 - **Switches providers mid-conversation** without losing context
-- **Integrates with your codebase** through 55+ specialized tools
+- **Integrates with your codebase** through 33 tool modules
 - **Automates workflows** via YAML-based StateGraph DSL
-- **Supports 5 domain verticals**: Coding, DevOps, RAG, Data Analysis, Research
+- **Supports 9 domain verticals**: Coding, DevOps, RAG, Data Analysis, Research, Security, IaC, Classification, Benchmark
 
 ### How does Victor differ from ChatGPT/Claude?
 
 | Feature | Victor | ChatGPT/Claude Web |
 |---------|--------|-------------------|
-| **Provider Choice** | 21 providers, switchable | 1 provider |
+| **Provider Choice** | 22 providers, switchable | 1 provider |
 | **Local Models** | Full support (Ollama, vLLM) | No |
 | **Code Integration** | Deep (AST, LSP, git, tests) | Upload files only |
 | **Offline Use** | Yes (air-gapped mode) | No |
@@ -40,7 +40,7 @@ Comprehensive FAQ for Victor AI Coding Assistant. Last updated: January 2026
 
 ### What providers are supported?
 
-Victor supports **21 LLM providers**:
+Victor supports **22 LLM providers**:
 
 **Local (No API Key):**
 - Ollama, LM Studio, vLLM, llama.cpp
@@ -417,7 +417,7 @@ workflows:
 
 ### Can I use Victor with existing tools (git, pytest, etc.)?
 
-**Yes!** Victor has 55+ built-in tools:
+**Yes!** Victor has 33 built-in tool modules:
 
 **Git:**
 ```bash

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Victor
 
-**Provider-agnostic coding assistant. Local or cloud, one CLI.**
+**Open-source agentic AI framework. Build, orchestrate, and evaluate AI agents across 22 providers.**
 
 [![PyPI version](https://badge.fury.io/py/victor-ai.svg)](https://pypi.org/project/victor-ai/)
 [![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
@@ -17,22 +17,39 @@
 
 ## Features
 
-- **21 LLM Providers** - Cloud (Anthropic, OpenAI, Google, Azure, AWS Bedrock) and local (Ollama, LM Studio, vLLM)
-- **55 Specialized Tools** - Across 5 domain verticals (Coding, DevOps, RAG, Data Analysis, Research)
-- **Air-Gapped Mode** - Full functionality with local models for secure, offline environments
-- **Semantic Codebase Search** - Context-aware code understanding with Tree-sitter and embeddings
-- **YAML Workflow DSL** - Define multi-step automation with StateGraph and checkpointing
-- **Multi-Agent Teams** - Coordinate specialized agents for complex tasks
-- **MCP Protocol Support** - Model Context Protocol for IDE integration
-- **Provider Switching** - Change models mid-conversation without losing context
+```
+┌─────────────────────────────────────────────────────────────┐
+│                     VICTOR FRAMEWORK                        │
+│                                                             │
+│  Agents ─── Teams ─── Workflows ─── Evaluation              │
+│    │          │          │              │                    │
+│  run()    Sequential   StateGraph    SWE-bench              │
+│  stream()  Parallel    YAML DSL      Harnesses              │
+│  chat()   Hierarchical Checkpoints   Code Quality           │
+│           Pipeline                                          │
+│                                                             │
+│  22 Providers │ 33 Tool Modules │ 9 Verticals │ 4 Scopes   │
+└─────────────────────────────────────────────────────────────┘
+```
+
+- **22 LLM Providers** — Cloud (Anthropic, OpenAI, Google, Azure, Bedrock, Vertex) + local (Ollama, LM Studio, vLLM)
+- **33 Tool Modules** — File ops, git, shell, web, search, docker, testing, refactoring, analysis
+- **9 Domain Verticals** — Coding, DevOps, RAG, Data Analysis, Research, Security, IaC, Classification, Benchmark
+- **Multi-Agent Teams** — 4 formations: sequential, parallel, hierarchical, pipeline
+- **Stateful Workflows** — YAML DSL compiled to StateGraph with typed state and checkpointing
+- **Air-Gapped Mode** — Full functionality with local models for secure, offline environments
 
 ## At a glance
 
 ```
-[You] -> [Victor CLI/TUI] -> [Context + Orchestration] -> [Providers] -> [Tools + Workflows] -> [Results]
-                                      |                     |
-                                      |                     +--> Local: Ollama, LM Studio, vLLM
-                                      +--> Files, tests, git       Cloud: Anthropic, OpenAI, etc
+                              ┌─────────────────────────────────┐
+                              │       Agent Orchestrator        │
+                              │                                 │
+[You] ──▶ [CLI/TUI/API] ──▶  │  ProviderManager ──▶ 22 LLMs   │ ──▶ [Response]
+                              │  ToolPipeline    ──▶ 33 Tools   │
+                              │  TeamCoordinator ──▶ Agents     │
+                              │  StateManager    ──▶ 4 Scopes   │
+                              └─────────────────────────────────┘
 ```
 
 ## Choose your path
@@ -55,38 +72,15 @@
 
 ## Supported Providers
 
-Victor supports **21 LLM providers** for maximum flexibility:
+Victor supports **22 LLM providers** — switch mid-conversation without losing context.
 
-### Cloud Providers
-
-| Provider | Models | Tool Calling | Vision | Setup |
-|----------|--------|--------------|--------|-------|
-| **Anthropic** | Claude Sonnet 4, Claude 3.5, Opus, Haiku | Yes | Yes | `ANTHROPIC_API_KEY` |
-| **OpenAI** | GPT-4o, GPT-4, o1-preview, o1-mini | Yes | Yes | `OPENAI_API_KEY` |
-| **Google** | Gemini 2.0 Flash, Gemini 1.5 Pro (2M context) | Yes | Yes | `GOOGLE_API_KEY` |
-| **Azure OpenAI** | GPT-4, Claude (via Azure) | Yes | Yes | `AZURE_OPENAI_API_KEY` |
-| **AWS Bedrock** | Claude 3, Llama 3, Titan | Yes | Yes | AWS credentials |
-| **xAI** | Grok | Yes | No | `XAI_API_KEY` |
-| **DeepSeek** | DeepSeek-V3, DeepSeek Coder | Yes | No | `DEEPSEEK_API_KEY` |
-| **Mistral** | Mistral Large, Mistral Small | Yes | Partial | `MISTRAL_API_KEY` |
-| **Cohere** | Command R, Command R+ | Yes | No | `COHERE_API_KEY` |
-| **Groq** | Llama, Mistral (ultra-fast, 300+ tok/s) | Yes | No | `GROQ_API_KEY` |
-| **Together AI** | 100+ open models | Yes | Partial | `TOGETHER_API_KEY` |
-| **Fireworks AI** | 50+ open models | Yes | Partial | `FIREWORKS_API_KEY` |
-| **OpenRouter** | 200+ models (unified API) | Yes | Partial | `OPENROUTER_API_KEY` |
-| **Replicate** | 20,000+ models | Yes | Partial | `REPLICATE_API_TOKEN` |
-| **Hugging Face** | 100,000+ models | Partial | Partial | `HF_API_KEY` (optional) |
-| **Moonshot** | Moonshot v1 (8K/32K/128K) | Yes | No | `MOONSHOT_API_KEY` |
-| **Cerebras** | Llama, Mistral (500+ tok/s) | Yes | No | `CEREBRAS_API_KEY` |
-
-### Local Providers (No API Key Required)
-
-| Provider | Best For | Setup |
-|----------|----------|-------|
-| **Ollama** | Beginners, ease of use | `ollama pull qwen2.5-coder:7b` |
-| **LM Studio** | GUI model management, Windows | Download from lmstudio.ai |
-| **vLLM** | Production, high throughput | `pip install vllm` |
-| **llama.cpp** | CPU inference, minimal footprint | Build from source |
+| Category | Providers |
+|----------|-----------|
+| **Frontier Cloud** | Anthropic, OpenAI, Google Gemini, Azure OpenAI |
+| **Cloud Platforms** | AWS Bedrock, Google Vertex |
+| **Specialized** | xAI, DeepSeek, Mistral, Groq, Cerebras, Moonshot, ZAI |
+| **Aggregators** | OpenRouter, Together AI, Fireworks AI, Replicate, Hugging Face |
+| **Local (air-gapped)** | Ollama, LM Studio, vLLM, llama.cpp |
 
 [Full Provider Reference](docs/reference/providers/)
 
@@ -150,11 +144,14 @@ result = await compiled.invoke({"query": "AI trends 2025"})
 
 | Capability | What it means | Docs |
 |------------|---------------|------|
-| **Provider switching** | Change models mid-thread without losing context | [Provider switching](docs/user-guide/index.md#1-provider-switching) |
-| **Workflows** | YAML DSL for multi-step automation | [Workflow development](docs/guides/workflow-development/) |
-| **Multi-agent teams** | Coordinate specialized agents | [Multi-agent](docs/guides/multi-agent/) |
-| **Tooling** | File ops, git, tests, search, web | [Tool catalog](docs/reference/tools/) |
-| **Verticals** | Domain-focused assistants | [Verticals](docs/reference/verticals/) |
+| **Agent abstractions** | `run()`, `stream()`, `chat()`, `run_workflow()`, `run_team()` | [Framework](docs/development/architecture/) |
+| **22 Providers** | Cloud + local LLMs; switch mid-thread without losing context | [Providers](docs/reference/providers/) |
+| **33 Tool modules** | File ops, git, shell, web, search, docker, testing, analysis | [Tool catalog](docs/reference/tools/) |
+| **Workflows** | YAML DSL compiled to StateGraph with typed state + checkpointing | [Workflows](docs/guides/workflow-development/) |
+| **Multi-agent teams** | 4 formations: sequential, parallel, hierarchical, pipeline | [Multi-agent](docs/guides/multi-agent/) |
+| **State management** | 4 scopes: workflow, conversation, team, global | [State](docs/development/architecture/) |
+| **9 Verticals** | Domain-focused agents with tools, prompts, and workflows | [Verticals](docs/reference/verticals/) |
+| **Evaluation** | Agent harnesses, code quality analysis, SWE-bench integration | [Evaluation](docs/development/) |
 
 ## Command quick reference
 

--- a/docker/demos/provider-features.py
+++ b/docker/demos/provider-features.py
@@ -212,7 +212,7 @@ async def demo_tool_calling():
 
     console.print("\n[bold]Response:[/bold]")
     if response.tool_calls:
-        console.print(f"[green]✓ Tool called![/green]")
+        console.print("[green]✓ Tool called![/green]")
         console.print(Markdown(f"```json\n{response.tool_calls}\n```"))
     else:
         console.print(response.content)
@@ -260,7 +260,7 @@ All demonstrations completed successfully! Victor is fully operational in Docker
 
 ---
 
-**Victor** - Open-source AI coding assistant
+**Victor** - Open-source agentic AI framework
 """
 
     report_file.write_text(report)
@@ -272,7 +272,7 @@ async def main():
     console.print(
         Panel.fit(
             "[bold magenta]Victor[/bold magenta]\n"
-            "[cyan]Open-source AI coding assistant[/cyan]\n"
+            "[cyan]Open-source agentic AI framework[/cyan]\n"
             "[dim]Docker Demo Suite[/dim]",
             border_style="magenta",
         )

--- a/docs/api-reference/providers.md
+++ b/docs/api-reference/providers.md
@@ -1047,7 +1047,7 @@ Capabilities are resolved in this order (later overrides earlier):
 
 ### Supported Providers
 
-Victor supports 21 LLM providers out of the box:
+Victor supports 22 LLM providers out of the box:
 
 | Provider | Name | Type | Tool Calling |
 |----------|------|------|--------------|

--- a/docs/assets/QUICK_START.md
+++ b/docs/assets/QUICK_START.md
@@ -94,8 +94,8 @@ graph TD
     B --> C[Providers]
     B --> D[Tools]
     B --> E[Workflows]
-    C --> F[21 LLM Providers]
-    D --> G[55 Tools]
+    C --> F[22 LLM Providers]
+    D --> G[33 Tool Modules]
 ```
 ```
 

--- a/docs/development/architecture/appendix.md
+++ b/docs/development/architecture/appendix.md
@@ -7,7 +7,7 @@
 
 | Aspect | Value |
 |--------|-------|
-| Purpose | Open-source, provider-agnostic coding assistant |
+| Purpose | Open-source agentic AI framework |
 | Core Tools | Dozens of built-in tools |
 | Architecture | Layered protocol-first design |
 | Key Pattern | Facade (orchestrator delegates to specialized components) |

--- a/docs/development/architecture/component-details.md
+++ b/docs/development/architecture/component-details.md
@@ -45,7 +45,7 @@ Senior systems architect analysis of framework-vertical integration.
 │  ┌──────────────┐ ┌──────────────┐ ┌──────────────┐ ┌──────────────┐        │
 │  │ToolPipeline  │ │Conversation  │ │ Provider     │ │ StateGraph   │        │
 │  │ • execute    │ │ Controller   │ │ Manager      │ │ • nodes      │        │
-│  │ • cache      │ │ • history    │ │ • 21 LLMs    │ │ • edges      │        │
+│  │ • cache      │ │ • history    │ │ • 22 LLMs    │ │ • edges      │        │
 │  │ • analytics  │ │ • stages     │ │ • fallback   │ │ • checkpoints│        │
 │  └──────────────┘ └──────────────┘ └──────────────┘ └──────────────┘        │
 └──────────────────────────────────┬──────────────────────────────────────────┘
@@ -255,7 +255,7 @@ async def load_extensions_async(cls) -> VerticalExtensions:
 |-----------|:------------:|-----------|
 | **Graph DSL** | 9 | LangGraph-compatible with copy-on-write optimization, cyclic support, checkpoints; lacks visual editor |
 | **Multi-Agent** | 8 | 5 formations, team specs, personas; CrewAI has better role definitions, AutoGen has conversation patterns |
-| **Provider Agnostic** | 10 | 21 providers, context preserved across switches; unique USP |
+| **Provider Agnostic** | 10 | 22 providers, context preserved across switches; unique USP |
 | **Observability** | 9 | Protocol-based backends, sampling, backpressure; LangSmith integration would push to 10 |
 | **Extensibility** | 8 | 15+ ISP protocols, entry_points for plugins; LangChain's ecosystem is larger |
 

--- a/docs/development/architecture/deep-dive.md
+++ b/docs/development/architecture/deep-dive.md
@@ -4,7 +4,7 @@ A comprehensive view of Victor's architecture, focusing on the new modular compo
 
 ## Overview
 
-Victor is a provider-agnostic coding assistant with a CLI/TUI front end, a core orchestrator, and modular tools/verticals. The architecture emphasizes:
+Victor is an agentic AI framework with a CLI/TUI front end, a core orchestrator, and modular tools/verticals. The architecture emphasizes:
 
 - **Lazy initialization** for faster startup
 - **SOLID principles** for maintainability
@@ -88,7 +88,7 @@ CLI/TUI  -->  Orchestrator  -->  Providers / Tools / Workflows / Verticals
 - **CLI/TUI**: User-facing entry point for chat and workflows
 - **Orchestrator**: Coordinates providers, tools, and workflows
 - **Providers**: Local or cloud LLM backends (21 supported)
-- **Tools**: File ops, git, testing, search, etc. (55 tools)
+- **Tools**: File ops, git, testing, search, etc. (33 tool modules)
 - **Verticals**: Domain presets (coding, research, devops, data, rag)
 
 ---

--- a/docs/development/architecture/overview.md
+++ b/docs/development/architecture/overview.md
@@ -19,40 +19,61 @@ flowchart TB
         STRM["StreamingController"]
     end
 
-    subgraph Providers["PROVIDERS (21)"]
+    subgraph Providers["PROVIDERS (22)"]
         ANT["Anthropic"]
         OAI["OpenAI"]
         OLL["Ollama"]
         MORE["..."]
     end
 
-    subgraph Verticals["VERTICALS (5)"]
+    subgraph Verticals["VERTICALS (9)"]
         COD["Coding"]
-        RES["Research"]
         DEV["DevOps"]
-        DAT["Data"]
         RAG["RAG"]
+        DAT["Data Analysis"]
+        RES["Research"]
+        SEC["Security"]
+        IAC["IaC"]
+        CLS["Classification"]
+        BEN["Benchmark"]
     end
 
-    subgraph Tools["TOOLS (55)"]
+    subgraph Tools["TOOLS (33 modules)"]
         FILE["File Ops"]
         GIT["Git"]
         SHELL["Shell"]
         WEB["Web"]
         SEARCH["Search"]
-        MORE2["..."]
+    end
+
+    subgraph Teams["TEAMS"]
+        SEQ["Sequential"]
+        PAR["Parallel"]
+        HIER["Hierarchical"]
+        PIPE["Pipeline"]
+    end
+
+    subgraph State["STATE (4 scopes)"]
+        WFS["Workflow"]
+        CONVS["Conversation"]
+        TMS["Team"]
+        GLS["Global"]
     end
 
     Clients --> Core
     Core --> Providers
     Core --> Verticals
     Core --> Tools
+    Core --> Teams
+    Core --> State
 
     style Clients fill:#e0e7ff,stroke:#4f46e5
     style Core fill:#d1fae5,stroke:#10b981
     style Providers fill:#fef3c7,stroke:#f59e0b
     style Verticals fill:#fce7f3,stroke:#ec4899
     style Tools fill:#cffafe,stroke:#06b6d4
+    style Teams fill:#e0e7ff,stroke:#6366f1
+    style State fill:#f3e8ff,stroke:#a855f7
 ```
 
 ## Request Flow
@@ -72,7 +93,8 @@ flowchart TB
                                     ▼
                  ┌─────────────────────────────────────────────────────────┐
                  │                      VerticalBase                       │
-                 │  (Coding | Research | DevOps | DataAnalysis | RAG)      │
+                 │  Coding | DevOps | RAG | DataAnalysis | Research       │
+                 │  Security | IaC | Classification | Benchmark           │
                  └─────────────────────────────────────────────────────────┘
                                     │
                                     ▼
@@ -86,22 +108,28 @@ flowchart TB
 
 | Layer | Components | Purpose |
 |-------|------------|---------|
-| **Clients** | CLI, HTTP API, MCP Server | User interaction |
+| **Clients** | CLI, HTTP API, MCP Server, VS Code | User interaction |
 | **Orchestrator** | AgentOrchestrator, Controllers | Coordinate execution |
-| **Verticals** | 5 built-in + custom | Domain specialization |
-| **Providers** | 21 LLM providers | Model abstraction |
-| **Tools** | 55 specialized tools | Capability execution |
-| **Workflows** | StateGraph, YAML | Multi-step processes |
+| **Providers** | 22 LLM providers | Model abstraction |
+| **Tools** | 33 tool modules | Capability execution |
+| **Workflows** | StateGraph, YAML DSL | Multi-step processes |
+| **Teams** | 4 formations (seq/par/hier/pipe) | Multi-agent coordination |
+| **State** | 4 scopes (workflow/conv/team/global) | Unified state management |
+| **Verticals** | 9 built-in + custom | Domain specialization |
 
 ## Verticals Overview
 
-| Vertical | Tools | Stages | Use Case |
-|----------|-------|--------|----------|
-| **Coding** | 30+ | 7 | Code analysis, refactoring, testing |
-| **Research** | 9 | 4 | Web search, synthesis, citations |
-| **DevOps** | 13 | 8 | Docker, CI/CD, infrastructure |
-| **DataAnalysis** | 11 | 5 | Pandas, visualization, statistics |
-| **RAG** | 10 | 5 | Document retrieval, vector search |
+| Vertical | Use Case |
+|----------|----------|
+| **Coding** | Code analysis, refactoring, testing |
+| **DevOps** | Docker, CI/CD, infrastructure |
+| **RAG** | Document retrieval, vector search |
+| **DataAnalysis** | Pandas, visualization, statistics |
+| **Research** | Web search, synthesis, citations |
+| **Security** | Vulnerability scanning, audit, compliance |
+| **IaC** | Infrastructure as Code management |
+| **Classification** | Text/data classification pipelines |
+| **Benchmark** | Agent evaluation and benchmarking |
 
 ## Provider Support
 
@@ -113,6 +141,7 @@ flowchart TB
 | Ollama | ✅ | ✅ | ✅ |
 | LM Studio | ✅ | ✅ | ✅ |
 | vLLM | ✅ | ✅ | ✅ |
+| ...and 16 more | | | |
 
 ## Tool Categories
 

--- a/docs/development/index.md
+++ b/docs/development/index.md
@@ -67,9 +67,9 @@ docs/
 | **Clients** | CLI, TUI, HTTP API, MCP | `victor/cli/`, `victor/integrations/` |
 | **Orchestrator** | AgentOrchestrator, Controllers | `victor/agent/` |
 | **Framework** | StateGraph, Workflows, Teams | `victor/framework/` |
-| **Verticals** | 5 built-in + custom | `victor/{vertical}/` |
-| **Providers** | 21 LLM providers | `victor/providers/` |
-| **Tools** | 55+ specialized tools | `victor/tools/` |
+| **Verticals** | 9 built-in + custom | `victor/{vertical}/` |
+| **Providers** | 22 LLM providers | `victor/providers/` |
+| **Tools** | 33 tool modules | `victor/tools/` |
 
 ### Verticals
 

--- a/docs/diagrams/architecture/system-overview.mmd
+++ b/docs/diagrams/architecture/system-overview.mmd
@@ -17,10 +17,10 @@ flowchart TB
 
     subgraph Core["CORE LAYER"]
         direction LR
-        Prov["Providers (21)<br/>Anthropic, OpenAI, Ollama..."]
-        Tools["Tools (55+)<br/>File, Git, Testing..."]
+        Prov["Providers (22)<br/>Anthropic, OpenAI, Ollama..."]
+        Tools["Tools (33)<br/>File, Git, Testing..."]
         WFs["Workflows<br/>YAML DSL & Executor"]
-        Verts["Verticals (5)<br/>Coding, DevOps, RAG..."]
+        Verts["Verticals (9)<br/>Coding, DevOps, RAG..."]
     end
 
     subgraph Infra["INFRASTRUCTURE LAYER"]

--- a/docs/diagrams/architecture/system-overview.svg
+++ b/docs/diagrams/architecture/system-overview.svg
@@ -146,7 +146,7 @@
     <g transform="translate(50, 50)">
       <rect x="0" y="0" width="250" height="100" rx="5" fill="url(#componentGradient)" stroke="#388E3C" stroke-width="2"/>
       <text x="125" y="30" text-anchor="middle" font-size="14" font-weight="bold" fill="#333">Providers</text>
-      <text x="125" y="50" text-anchor="middle" font-size="12" fill="#666">21 LLM Providers</text>
+      <text x="125" y="50" text-anchor="middle" font-size="12" fill="#666">22 LLM Providers</text>
       <text x="125" y="70" text-anchor="middle" font-size="10" fill="#888">Anthropic, OpenAI, Google,</text>
       <text x="125" y="85" text-anchor="middle" font-size="10" fill="#888">Ollama, vLLM, DeepSeek...</text>
     </g>
@@ -155,7 +155,7 @@
     <g transform="translate(350, 50)">
       <rect x="0" y="0" width="250" height="100" rx="5" fill="url(#componentGradient)" stroke="#388E3C" stroke-width="2"/>
       <text x="125" y="30" text-anchor="middle" font-size="14" font-weight="bold" fill="#333">Tools</text>
-      <text x="125" y="50" text-anchor="middle" font-size="12" fill="#666">55+ Specialized Tools</text>
+      <text x="125" y="50" text-anchor="middle" font-size="12" fill="#666">33 Tool Modules</text>
       <text x="125" y="70" text-anchor="middle" font-size="10" fill="#888">File, Git, Testing, Search,</text>
       <text x="125" y="85" text-anchor="middle" font-size="10" fill="#888">Web Scraping, Code Editing...</text>
     </g>
@@ -173,7 +173,7 @@
     <g transform="translate(950, 50)">
       <rect x="0" y="0" width="250" height="100" rx="5" fill="url(#componentGradient)" stroke="#388E3C" stroke-width="2"/>
       <text x="125" y="30" text-anchor="middle" font-size="14" font-weight="bold" fill="#333">Verticals</text>
-      <text x="125" y="50" text-anchor="middle" font-size="12" fill="#666">5 Domain Verticals</text>
+      <text x="125" y="50" text-anchor="middle" font-size="12" fill="#666">9 Domain Verticals</text>
       <text x="125" y="70" text-anchor="middle" font-size="10" fill="#888">Coding, DevOps, RAG,</text>
       <text x="125" y="85" text-anchor="middle" font-size="10" fill="#888">Data Analysis, Research</text>
     </g>

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -663,8 +663,8 @@ victor keys --set anthropic --keyring
 ## Next Steps
 
 - [User Guide](../user-guide/) - Daily usage patterns
-- [Provider Reference](../reference/providers/) - All 21 providers
-- [Tool Catalog](../reference/tools/catalog.md) - 55+ tools
+- [Provider Reference](../reference/providers/) - All 22 providers
+- [Tool Catalog](../reference/tools/catalog.md) - 33 tool modules
 - [Workflow Guide](../guides/workflow-development/) - Automation
 
 ---

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -4,14 +4,14 @@ Welcome to Victor! This guide will help you install, configure, and run Victor i
 
 ## What is Victor?
 
-**Victor** is a provider-agnostic AI coding assistant that supports 21 LLM providers (both local and cloud) through a unified CLI/TUI interface.
+**Victor** is an open-source agentic AI framework that supports 22 LLM providers (both local and cloud) through a unified CLI/TUI interface.
 
 **Key Features:**
-- **21 LLM Providers**: Cloud (Anthropic, OpenAI, Google) and local (Ollama, LM Studio, vLLM)
+- **22 LLM Providers**: Cloud (Anthropic, OpenAI, Google, Vertex) and local (Ollama, LM Studio, vLLM)
 - **Provider Switching**: Switch between any provider mid-conversation without losing context
 - **No API Key Required**: Use local models by default for privacy and cost savings
-- **55+ Tools**: File operations, code editing, git, testing, search, and more
-- **5 Domain Verticals**: Specialized assistants for Coding, DevOps, RAG, Data Analysis, Research
+- **33 Tool Modules**: File operations, code editing, git, testing, search, and more
+- **9 Domain Verticals**: Coding, DevOps, RAG, Data Analysis, Research, Security, IaC, Classification, Benchmark
 - **YAML Workflows**: Define multi-step automation with scheduling and versioning
 - **Multi-Agent Teams**: Coordinate specialized AI agents for complex tasks
 
@@ -132,8 +132,8 @@ Customize Victor for your needs:
 After getting started:
 
 1. **[User Guide](../user-guide/)** - Daily usage patterns and workflows
-2. **[Provider Reference](../reference/providers/)** - All 21 providers detailed
-3. **[Tool Catalog](../reference/tools/catalog.md)** - 55+ available tools
+2. **[Provider Reference](../reference/providers/)** - All 22 providers detailed
+3. **[Tool Catalog](../reference/tools/catalog.md)** - 33 tool modules
 4. **[Workflow DSL](../guides/workflow-development/dsl.md)** - YAML workflow automation
 
 ## Need Help?

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -182,8 +182,8 @@ victor tools
 **Expected output:**
 ```
 Victor AI v0.x.x
-21 providers available
-55 tools available
+22 providers available
+33 tools available
 ```
 
 ### Step 3: Choose Your Model

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -296,7 +296,7 @@ Now that you have Victor running:
 1. **Configure profiles** - Create shortcuts for your favorite providers
    - [Configuration Guide](configuration.md)
 
-2. **Learn the tools** - Explore Victor's 55+ tools
+2. **Learn the tools** - Explore Victor's 33 tool modules
    - [Tool Catalog](../reference/tools/catalog.md)
 
 3. **Set up project context** - Teach Victor about your codebase

--- a/docs/guides/VICTOR_AS_MCP_SERVER.md
+++ b/docs/guides/VICTOR_AS_MCP_SERVER.md
@@ -1,6 +1,6 @@
 # Victor as an MCP Server Toolkit
 
-This guide covers how to run Victor as a Model Context Protocol (MCP) server, enabling external clients like Claude Desktop to use Victor's 55+ specialized tools across 5 domain verticals.
+This guide covers how to run Victor as a Model Context Protocol (MCP) server, enabling external clients like Claude Desktop to use Victor's 33 tool modules across 9 domain verticals.
 
 ## Overview
 
@@ -82,7 +82,7 @@ In Claude Desktop, you should see Victor's tools available. Try asking:
 
 ## Available Tools
 
-Victor exposes 55+ tools across 5 domain verticals:
+Victor exposes 33 tool modules across 9 domain verticals:
 
 ### Coding Tools
 | Tool | Description |

--- a/docs/guides/tool-reference.md
+++ b/docs/guides/tool-reference.md
@@ -1,6 +1,6 @@
 # Tool Reference
 
-**Quick reference for Victor's 55+ specialized tools.**
+**Quick reference for Victor's 33 tool modules.**
 
 ## Tool Categories
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,7 +2,7 @@
 
 # Victor Documentation
 
-**Provider-agnostic AI coding assistant with multi-provider support, workflow orchestration, and extensible tool system**
+**Open-source agentic AI framework. Build, orchestrate, and evaluate AI agents across 22 providers.**
 
 [![PyPI version](https://badge.fury.io/py/victor-ai.svg)](https://pypi.org/project/victor-ai/)
 [![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
@@ -15,16 +15,16 @@
 
 ## Welcome! 👋
 
-Victor is an open-source AI coding assistant supporting **21 LLM providers** with **55 specialized tools** across **5 domain verticals**. Whether you need local development with Ollama, cloud capabilities with Claude/GPT, or enterprise deployments with Azure/AWS, Victor provides a unified interface with powerful features like semantic codebase search, YAML-first workflows, multi-agent coordination, and air-gapped mode support.
+Victor is an open-source agentic AI framework supporting **22 LLM providers** with **33 tool modules** across **9 domain verticals**. Whether you need local development with Ollama, cloud capabilities with Claude/GPT, or enterprise deployments with Azure/AWS, Victor provides a unified interface with powerful features like multi-agent teams, stateful workflows, event sourcing, semantic codebase search, and air-gapped mode support.
 
 ## What is Victor?
 
-Victor is a **provider-agnostic AI coding assistant** that gives you the freedom to choose between local and cloud LLM providers through a single, consistent CLI/TUI interface. Built with extensibility in mind, Victor's vertical architecture lets you specialize workflows for coding, DevOps, RAG, data analysis, and research tasks.
+Victor is an **agentic AI framework** that gives you the freedom to choose between local and cloud LLM providers through a single, consistent CLI/TUI interface. Built with extensibility in mind, Victor's vertical architecture lets you specialize workflows for coding, DevOps, RAG, data analysis, research, security, IaC, classification, and benchmarking tasks.
 
 ### Key Highlights
 
-- 🌐 **21 LLM Providers** - Switch between Anthropic, OpenAI, Google, Azure, AWS Bedrock, Ollama, LM Studio, vLLM, and more
-- 🛠️ **55 Specialized Tools** - Across 5 domain verticals (Coding, DevOps, RAG, Data Analysis, Research)
+- 🌐 **22 LLM Providers** - Switch between Anthropic, OpenAI, Google, Azure, AWS Bedrock, Vertex, Ollama, LM Studio, vLLM, and more
+- 🛠️ **33 Tool Modules** - Across 9 domain verticals (Coding, DevOps, RAG, Data Analysis, Research, Security, IaC, Classification, Benchmark)
 - 🔄 **YAML-First Workflows** - Define multi-step automation with StateGraph DSL and checkpointing
 - 🔒 **Air-Gapped Mode** - Full functionality with local models for secure, offline environments
 - 🔍 **Semantic Codebase Search** - Context-aware code understanding with Tree-sitter and embeddings
@@ -93,6 +93,10 @@ Domain-specific documentation.
 - **[RAG](verticals/rag.md)** - Document ingestion, vector search, retrieval
 - **[Data Analysis](verticals/data-analysis.md)** - Pandas, visualization, statistics
 - **[Research](verticals/research.md)** - Web search, citations, synthesis
+- **[Security](verticals/security.md)** - Vulnerability scanning, audit, compliance
+- **[IaC](verticals/iac.md)** - Infrastructure as Code management
+- **[Classification](verticals/classification.md)** - Text/data classification pipelines
+- **[Benchmark](verticals/benchmark.md)** - Agent evaluation and benchmarking
 
 ## Project Information
 
@@ -147,14 +151,14 @@ docker run -it -v ~/.victor:/root/.victor ghcr.io/vjsingh1984/victor:latest
                           ▼
 ┌───────────┬─────────────┬───────────────┬───────────────────────┐
 │ PROVIDERS │   TOOLS     │  WORKFLOWS    │  VERTICALS            │
-│  21       │   55        │  StateGraph   │  Coding/DevOps/RAG/   │
-│           │             │  + YAML       │  DataAnalysis/Research│
+│  22       │   33        │  StateGraph   │  9 domains: Coding,   │
+│           │  modules    │  + YAML       │  DevOps, RAG, + 6 more│
 └───────────┴─────────────┴───────────────┴───────────────────────┘
 ```
 
 ### Key Concepts
 
-- **Provider Agnosticism** - Switch between 21 LLM providers seamlessly
+- **Provider Agnosticism** - Switch between 22 LLM providers seamlessly
 - **Vertical Architecture** - Self-contained domains with specialized tools
 - **YAML Workflows** - Declarative workflow definitions with Python escape hatches
 - **StateGraph DSL** - LangGraph-compatible workflow API for complex automation

--- a/docs/index.md
+++ b/docs/index.md
@@ -101,7 +101,7 @@ Domain-specific documentation.
 ## Project Information
 
 ### Version
-**Current Version:** v0.5.0 (see [CHANGELOG](../CHANGELOG.md))
+**Current Version:** v0.5.3 (see [CHANGELOG](../CHANGELOG.md))
 
 ### Links
 - **[GitHub Repository](https://github.com/vjsingh1984/victor)** - Source code and issues

--- a/docs/reference/api/http-api.md
+++ b/docs/reference/api/http-api.md
@@ -1,6 +1,6 @@
 # HTTP API Reference
 
-REST API for Victor's AI coding assistant capabilities.
+REST API for Victor's agentic AI framework capabilities.
 
 ## Overview
 

--- a/docs/reference/api/mcp-server.md
+++ b/docs/reference/api/mcp-server.md
@@ -1,6 +1,6 @@
 # Victor as an MCP Server Toolkit
 
-This guide covers how to run Victor as a Model Context Protocol (MCP) server, enabling external clients like Claude Desktop to use Victor's 55+ specialized tools across 5 domain verticals.
+This guide covers how to run Victor as a Model Context Protocol (MCP) server, enabling external clients like Claude Desktop to use Victor's 33 tool modules across 9 domain verticals.
 
 ## Overview
 
@@ -82,7 +82,7 @@ In Claude Desktop, you should see Victor's tools available. Try asking:
 
 ## Available Tools
 
-Victor exposes 55+ tools across 5 domain verticals:
+Victor exposes 33 tool modules across 9 domain verticals:
 
 ### Coding Tools
 | Tool | Description |

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -6,17 +6,17 @@ Complete reference documentation for Victor AI Assistant.
 
 | Reference | Description |
 |-----------|-------------|
-| [**Providers**](providers/) | All 21 LLM providers with setup, models, and configuration |
-| [**Tools**](tools/) | 55+ tools organized by category |
+| [**Providers**](providers/) | All 22 LLM providers with setup, models, and configuration |
+| [**Tools**](tools/) | 33 tool modules organized by category |
 | [**Configuration**](configuration/) | Complete configuration reference (profiles, API keys, MCP) |
 | [**API**](api/) | HTTP API, MCP server, Python package API |
-| [**Verticals**](verticals/) | 5 domain-specific assistants |
+| [**Verticals**](verticals/) | 9 domain-specific assistants |
 
 ---
 
 ## Provider Reference
 
-Complete reference for all 21 supported LLM providers.
+Complete reference for all 22 supported LLM providers.
 
 ### Local Providers (No API Key Required)
 
@@ -35,7 +35,7 @@ Complete reference for all 21 supported LLM providers.
 | OpenAI | GPT-4, o1 | Pay-per-use | `export OPENAI_API_KEY=sk-...` |
 | Google | Gemini 2.0 | Pay-per-use | `export GOOGLE_API_KEY=...` |
 | Azure | Azure OpenAI | Pay-per-use | Azure portal setup |
-| And 17 more... | See full list | See full list | See full list |
+| And 14 more... | See full list | See full list | See full list |
 
 [**Full Provider Reference →**](providers/)
 
@@ -43,7 +43,7 @@ Complete reference for all 21 supported LLM providers.
 
 ## Tool Reference
 
-55+ tools organized by category for code operations, testing, search, and more.
+33 tool modules organized by category for code operations, testing, search, and more.
 
 ### Tool Categories
 

--- a/docs/reference/providers-comparison.md
+++ b/docs/reference/providers-comparison.md
@@ -14,7 +14,6 @@
 | **vLLM** | ✅ Native | ✅ | Varies | ✅ | Free |
 | **Azure OpenAI** | ✅ Native | ✅ | 128K | ❌ | $$$ |
 | **AWS Bedrock** | ✅ Native | ✅ | Varies | ❌ | $$$ |
-| **Cohere** | ✅ Native | ✅ | 128K | ❌ | $$ |
 | **Mistral** | ✅ Native | ✅ | 32K | ❌ | $$ |
 
 ## Decision Tree
@@ -29,7 +28,7 @@ flowchart TD
     LOCAL -->|CPU/Any| OLLAMA["Ollama"]
     LOCAL -->|GUI| LMSTUDIO["LM Studio"]
 
-    CLOUD -->|Free| COHERE["Cohere Free"]
+    CLOUD -->|Free| GROQ["Groq Free Tier"]
     CLOUD -->|$$| GOOGLE["Gemini"]
     CLOUD -->|$$$| FEATURES{"Features?"}
 
@@ -117,7 +116,6 @@ victor chat --provider ollama --model llama3
 | **Anthropic** | $3.00 | $15.00 |
 | **OpenAI** | $5.00 | $15.00 |
 | **Google** | $0.50 | $1.50 |
-| **Cohere** | $0.50 | $1.50 |
 | **Ollama** | Free | Free |
 
 ## Performance

--- a/docs/reference/quick-reference.md
+++ b/docs/reference/quick-reference.md
@@ -1,6 +1,6 @@
 # Victor Quick Reference
 
-Essential commands, options, and configurations for Victor AI coding assistant.
+Essential commands, options, and configurations for the Victor agentic AI framework.
 
 ---
 

--- a/docs/user-guide/index.md
+++ b/docs/user-guide/index.md
@@ -16,7 +16,7 @@ This guide covers everything you need to use Victor effectively, from basic conv
 | **CLI Commands** | [CLI Reference](cli-reference.md) | All commands and options |
 | **Tools** | [Tools Guide](tools.md) | Tool system, selection, execution |
 | **Session Management** | [Session Management](session-management.md) | Save and restore sessions |
-| **Providers** | [Provider Guide](providers.md) | 21 LLM providers setup and switching |
+| **Providers** | [Provider Guide](providers.md) | 22 LLM providers setup and switching |
 | **Workflows** | [Workflows Guide](workflows.md) | YAML-based automation |
 | **Configuration** | [Configuration →](../reference/configuration/) | Profiles and settings |
 
@@ -94,7 +94,7 @@ Start with Claude, continue with GPT-4, finish with a local model—all in one c
 
 - **Context Independence**: Conversation history managed separately from LLM
 - **Instant Switching**: Use `/provider` command anytime
-- **Full Support**: All 21 providers support context preservation
+- **Full Support**: All 22 providers support context preservation
 
 [Provider Guide →](providers.md)
 
@@ -112,7 +112,7 @@ Three modes for different workflows:
 
 ### 3. Tools System
 
-55+ tools organized by category:
+33 tool modules organized by category:
 
 - **File Operations** (12 tools): Read, write, edit, search files
 - **Git** (8 tools): Version control, commits, branches

--- a/docs/user-guide/providers.md
+++ b/docs/user-guide/providers.md
@@ -1,6 +1,6 @@
 # Provider Guide
 
-Complete guide to using LLM providers in Victor. Victor supports 21 providers, from local inference to cloud APIs, with seamless mid-conversation switching.
+Complete guide to using LLM providers in Victor. Victor supports 22 providers, from local inference to cloud APIs, with seamless mid-conversation switching.
 
 ## What is a Provider?
 

--- a/docs/user-guide/tools.md
+++ b/docs/user-guide/tools.md
@@ -1,6 +1,6 @@
 # Tools Guide
 
-Victor provides 55+ specialized tools that enable the AI assistant to interact with your codebase, execute commands, search the web, and perform complex operations. This guide covers how tools work, how they are selected, and how to configure them.
+Victor provides 33 tool modules that enable the AI assistant to interact with your codebase, execute commands, search the web, and perform complex operations. This guide covers how tools work, how they are selected, and how to configure them.
 
 ## Overview
 
@@ -470,7 +470,7 @@ If wrong tools are being selected:
 
 ## Reference
 
-- [Full Tool Catalog](../reference/tools/catalog.md) - All 55+ tools with parameters
+- [Full Tool Catalog](../reference/tools/catalog.md) - All 33 tool modules with parameters
 - [Tool Calling Details](../reference/tools/tool-calling.md) - Provider-specific behavior
 - [Configuration Reference](../reference/configuration/) - All settings
 - [Custom Tool Tutorial](../guides/custom-tools/) - Build your own tools

--- a/docs/user-guide/troubleshooting.md
+++ b/docs/user-guide/troubleshooting.md
@@ -25,7 +25,7 @@ victor logs --tail 50
 
 **Expected Output**:
 - Version should be latest: `victor 0.x.x`
-- Providers should list 21 providers
+- Providers should list 22 providers
 - Chat should respond successfully
 - Config should show your profiles
 - Logs should show recent activity
@@ -267,7 +267,7 @@ victor chat --provider together "Hello"
 ```bash
 victor providers
 
-# Should list 21 providers
+# Should list 22 providers
 ```
 
 **2. Install provider extras**:

--- a/examples/victor_mcp_toolkit_demo.py
+++ b/examples/victor_mcp_toolkit_demo.py
@@ -17,12 +17,16 @@
 This demo showcases how to run Victor as an MCP server toolkit, configure which
 tools to expose, and connect from external clients.
 
-Victor exposes 55+ tools across 5 domain verticals:
+Victor exposes 33 tool modules across 9 domain verticals:
 - Coding: file operations, git, code search, testing
 - DevOps: Docker, Terraform, CI/CD, Kubernetes
 - RAG: document ingestion, vector search, retrieval
 - Data Analysis: Pandas, visualization, statistics
 - Research: web search, summarization, citations
+- Security: vulnerability scanning, audit, compliance
+- IaC: infrastructure as code management
+- Classification: text/data classification pipelines
+- Benchmark: agent evaluation and benchmarking
 
 Usage:
     # Run demo showing MCP server capabilities
@@ -219,7 +223,7 @@ async def run_demo():
     print("Victor MCP Toolkit Demo")
     print("=" * 70)
     print()
-    print("Victor can be run as an MCP server, exposing its 55+ tools to external")
+    print("Victor can be run as an MCP server, exposing its 33 tool modules to external")
     print("clients like Claude Desktop, VS Code, or any MCP-compatible application.")
     print()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,8 +18,8 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "victor-ai"
-version = "0.5.2"
-description = "Open-source AI coding assistant with multi-provider support, workflow orchestration, and extensible tool system"
+version = "0.5.3"
+description = "Open-source agentic AI framework with multi-provider support, workflow orchestration, and extensible tool system"
 readme = "README.md"
 license = {text = "Apache-2.0"}
 authors = [

--- a/rust/README.md
+++ b/rust/README.md
@@ -1,6 +1,6 @@
 # Victor Native Extensions
 
-High-performance Rust implementations of CPU-intensive operations for the Victor AI coding assistant.
+High-performance Rust implementations of CPU-intensive operations for the Victor agentic AI framework.
 
 ## Features
 

--- a/victor/__init__.py
+++ b/victor/__init__.py
@@ -40,7 +40,12 @@ For coding-specific features:
     from victor.coding.codebase import CodebaseIndex
 """
 
-__version__ = "0.5.1"
+try:
+    from importlib.metadata import version as _get_version
+
+    __version__ = _get_version("victor-ai")
+except Exception:
+    __version__ = "0.0.0"  # fallback for editable installs without metadata
 __author__ = "Vijaykumar Singh"
 __email__ = "singhvjd@gmail.com"
 __license__ = "Apache-2.0"

--- a/victor/agent/coordinators/__init__.py
+++ b/victor/agent/coordinators/__init__.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Tool coordination package for Victor AI coding assistant.
+"""Tool coordination package for Victor agentic AI framework.
 
 This package contains coordinator classes that extract and consolidate
 specific coordination responsibilities from the AgentOrchestrator:

--- a/victor/framework/__init__.py
+++ b/victor/framework/__init__.py
@@ -1193,5 +1193,10 @@ try:
 except ImportError:
     _WORKFLOW_ENGINE_EXPORTS = []
 
-# Version of the framework API
-__version__ = "0.5.1"
+# Version sourced from pyproject.toml via importlib.metadata
+try:
+    from importlib.metadata import version as _get_version
+
+    __version__ = _get_version("victor-ai")
+except Exception:
+    __version__ = "0.0.0"

--- a/victor/ui/cli.py
+++ b/victor/ui/cli.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Command-line interface for Victor - Open-source AI coding assistant."""
+"""Command-line interface for Victor - Open-source agentic AI framework."""
 
 import typer
 from rich.console import Console
@@ -49,7 +49,7 @@ from victor.ui.commands.workflow import workflow_app
 
 app = typer.Typer(
     name="victor",
-    help="Victor - Open-source AI coding assistant with multi-provider support.",
+    help="Victor - Open-source agentic AI framework with multi-provider support.",
     add_completion=False,
 )
 
@@ -105,7 +105,7 @@ def callback(
         help="Show version and exit",
     ),
 ) -> None:
-    """Victor - Open-source AI coding assistant with multi-provider support."""
+    """Victor - Open-source agentic AI framework with multi-provider support."""
     if ctx.invoked_subcommand is None:
         _run_default_interactive()
 

--- a/victor/ui/commands/chat.py
+++ b/victor/ui/commands/chat.py
@@ -10,6 +10,7 @@ from rich.console import Console
 from rich.markdown import Markdown
 from rich.panel import Panel
 from rich.prompt import Confirm, Prompt
+from rich.table import Table
 
 from victor.agent.orchestrator import AgentOrchestrator
 from victor.config.settings import load_settings, ProfileConfig
@@ -478,7 +479,6 @@ async def run_oneshot(
     start_time = time.time()
     session_id = str(uuid.uuid4())
     success = False
-    token_count = 0
     tool_calls_made = 0
     task_type: Optional[str] = None
 
@@ -570,8 +570,6 @@ async def run_oneshot(
             )
 
         success = True
-        if usage_stats:
-            token_count = getattr(usage_stats, "total_tokens", 0) or 0
         if hasattr(agent, "get_session_metrics"):
             metrics = agent.get_session_metrics()
             tool_calls_made = metrics.get("tool_calls", 0) if metrics else 0
@@ -788,7 +786,7 @@ async def _run_cli_repl(
     """Run the CLI-based REPL (fallback for unsupported terminals)."""
     vertical_display = f"  [bold]Vertical:[/ ] [magenta]{vertical_name}[/]" if vertical_name else ""
     panel_content = (
-        f"[bold blue]Victor[/] - Open-source AI coding assistant\n\n"
+        f"[bold blue]Victor[/] - Open-source agentic AI framework\n\n"
         f"[bold]Provider:[/ ] [cyan]{profile_config.provider}[/]  "
         f"[bold]Model:[/ ] [cyan]{profile_config.model}[/]{vertical_display}\n\n"
         f"Type [bold]/help[/] for commands, [bold]/exit[/] or [bold]Ctrl+D[/] to quit."

--- a/vscode-victor/README.md
+++ b/vscode-victor/README.md
@@ -1,6 +1,6 @@
 # Victor AI - VS Code Extension
 
-AI-powered coding assistant with multi-provider support, semantic code search, and 55 enterprise tools for professional development workflows.
+AI-powered agentic AI framework with multi-provider support, semantic code search, and 33 tool modules for professional development workflows.
 
 [![GitHub](https://img.shields.io/badge/GitHub-vjsingh1984%2Fvictor-blue)](https://github.com/vjsingh1984/victor)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://github.com/vjsingh1984/victor/blob/main/LICENSE)


### PR DESCRIPTION
## Summary

- **Identity reframe**: All documentation now describes Victor as an "agentic AI framework" instead of "coding assistant" — across 36+ files including README, architecture docs, CLI strings, demos, and diagrams
- **Correct capability counts**: 22 providers (was 21), 33 tool modules (was 55+), 9 verticals (was 5-6) — verified via codebase grep
- **Single-source versioning**: `__version__` now reads from `pyproject.toml` via `importlib.metadata`, eliminating version drift across `victor/__init__.py`, `victor/framework/__init__.py`, and `docs/index.md`
- **Removed non-existent Cohere provider** from README and provider comparison docs (only available through Bedrock)
- **Fixed pre-existing lint errors**: F541, F821, F841 ruff violations in `chat.py` and `provider-features.py`
- **Architecture diagrams**: Added Teams, State, Events/CQRS, Evaluation subsystems to all architecture mermaid and ASCII diagrams
- **Version bump to 0.5.3** with CHANGELOG entries

## Test plan

- [ ] CI passes (lint, black, mypy, unit tests)
- [ ] `grep -rn "coding assistant" README.md ARCHITECTURE.md docs/architecture/ docs/development/architecture/` returns no results
- [ ] `python -c "import victor; print(victor.__version__)"` prints `0.5.3`
- [ ] `grep -rn "Cohere" README.md docs/reference/providers-comparison.md` returns no standalone provider references
- [ ] After merge, tag `v0.5.3` to trigger release workflow