### PR TITLE
Fix ObservabilityBus missing emit_metric method

### DIFF
--- a/victor/core/events/backends.py
+++ b/victor/core/events/backends.py
@@ -669,6 +669,38 @@ class ObservabilityBus:
             )
         )
 
+    def emit_metric(
+        self,
+        metric_name: str,
+        value: float,
+        unit: str = "",
+        tags: Optional[Dict[str, str]] = None,
+    ) -> None:
+        """Emit a metric event (fire-and-forget).
+
+        Convenience method that wraps emit() for metric data.
+
+        Args:
+            metric_name: Name of the metric (e.g., "latency", "token_count").
+            value: Metric value.
+            unit: Unit of measurement (e.g., "ms", "count").
+            tags: Optional key-value tags for the metric.
+        """
+        import asyncio
+
+        asyncio.create_task(
+            self.emit(
+                topic=f"metric.{metric_name}",
+                data={
+                    "metric_name": metric_name,
+                    "value": value,
+                    "unit": unit,
+                    "tags": tags or {},
+                },
+                source="observability",
+            )
+        )
+
 
 class AgentMessageBus:
     """Specialized event bus for cross-agent communication.


### PR DESCRIPTION
## Summary

- **Bug**: `victor chat` crashed with `AttributeError: 'ObservabilityBus' object has no attribute 'emit_metric'` when max continuation prompts were reached during a chat session
- **Root cause**: `ObservabilityBus` had `emit()` (async) and `emit_error()` (sync fire-and-forget) but was missing `emit_metric()`, which `continuation_strategy.py:827` and `native/observability.py:251` both call
- **Fix**: Add `emit_metric()` as a fire-and-forget convenience method, following the same `asyncio.create_task` pattern as `emit_error()`
- **Tests**: 3 new regression tests verifying emit_metric behavior and existence

## Test plan

- [x] `pytest tests/unit/core/events/test_event_backends.py -v` — 30 tests pass
- [x] `ruff check` + `black --check` pass
- [ ] CI passes
- [ ] Manual: `victor chat` → trigger continuation prompts → no crash