### PR TITLE
Merge develop to main for release

### DIFF
--- a/victor/agent/coordinators/tool_coordinator.py
+++ b/victor/agent/coordinators/tool_coordinator.py
@@ -468,6 +468,14 @@ class ToolCoordinator:
         if self._enabled_tools:
             return self._enabled_tools
 
+        # Fall back to orchestrator's enabled tools (if set before coordinator was initialized)
+        if hasattr(self, "_orchestrator") and self._orchestrator:
+            orch_tools = getattr(self._orchestrator, "_enabled_tools", None)
+            if orch_tools:
+                # Sync to coordinator's state for future access
+                self._enabled_tools = orch_tools
+                return orch_tools
+
         # Fall back to all available tools
         return self.get_available_tools()
 

--- a/victor/agent/orchestrator.py
+++ b/victor/agent/orchestrator.py
@@ -4058,7 +4058,10 @@ class AgentOrchestrator(ModeAwareMixin, CapabilityRegistryMixin):
             tiered_config: Optional TieredToolConfig to propagate for stage filtering.
         """
         self._enabled_tools = tools
-        self._tool_coordinator.set_enabled_tools(tools)
+        # Only propagate to tool_coordinator if it's already initialized
+        # to avoid eager materialization during orchestrator setup
+        if hasattr(self, "_tool_coordinator") and self._tool_coordinator.initialized:
+            self._tool_coordinator.set_enabled_tools(tools)
 
         # Apply to vertical context and tool access controller
         self._apply_vertical_tools(tools)


### PR DESCRIPTION
## Summary
Merging `develop` branch to `main` for release. This includes the CI/CD fixes that were blocking the release.

## Changes Included

### Fix: Defer tool_coordinator initialization to preserve lazy runtime
- Fixed `interaction_runtime_lazy` KPI guardrail failure
- Modified `orchestrator.py` to only call `tool_coordinator.set_enabled_tools()` if already initialized
- Modified `tool_coordinator.py` to add fallback to orchestrator's `_enabled_tools`

### Previous Changes (from develop)
- P0-P4 framework vertical integration remediation
- Documentation updates with infographics-first approach
- Cleanup of 51,660 lines of outdated analysis reports

## CI Status
All checks passing:
- ✅ Format Check (Black)
- ✅ Lint (Ruff)
- ✅ Type Check (MyPy)
- ✅ Import Check with Startup KPI Guardrails
- ✅ Strict Fallback Guards tests
- ✅ Security Quick Scan

## Checklist
- [x] All CI tests passing
- [x] Code formatting applied
- [x] Lint checks passing
- [x] Type checks passing
- [x] Import validation with KPI guardrails passing