### PR TITLE
fix: remove xdist, serial execution in CI shards

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -1,6 +1,6 @@
-# Optimized Test Workflow with Parallel Execution and Sharding
-# Uses pytest-xdist for parallel test execution within jobs
-# Splits tests across multiple shards for faster matrix execution
+# Test Workflow with Sharding
+# Tests run sequentially within each shard for reliable isolation
+# Splits tests across 6 shards for parallel matrix execution
 
 name: CI - Tests
 
@@ -63,15 +63,13 @@ jobs:
           pip install -e ./victor-sdk
           # Install with dev dependencies for testing
           pip install -e ".[dev,api]"
-          # Install pytest-xdist for parallel execution
-          pip install pytest-xdist pytest-split
+          # Install pytest-split for sharding across CI jobs
+          pip install pytest-split
 
       - name: Run tests (sharded)
         run: |
           pytest tests/unit \
             -m "not slow and not integration" \
-            --dist loadscope \
-            -n auto \
             --splitting-algorithm=least_duration \
             --splits=6 \
             --group=${{ matrix.shard }} \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,7 +76,7 @@ jobs:
 
       - name: Run tests
         run: |
-          pytest tests/unit -v --tb=short -n auto --dist loadscope
+          pytest tests/unit -v --tb=short
 
       - name: Run linting
         run: |

--- a/Makefile
+++ b/Makefile
@@ -48,14 +48,11 @@ install:
 
 install-dev:
 	pip install -e ".[dev,docs,build]"
-	pip install pre-commit pytest-xdist pytest-split
+	pip install pre-commit pytest-split
 	pre-commit install || true
 
 test:
-	pytest tests/unit -v --tb=short -n 2 --dist loadscope --timeout=120
-
-test-parallel:
-	pytest tests/unit -v --tb=short -n auto --dist loadscope --timeout=120
+	pytest tests/unit -v --tb=short --timeout=120
 
 test-definition-boundaries:
 	@echo "Definition import boundaries enforced by SDK contract tests"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -128,7 +128,7 @@ dev = [
     "pytest-mock>=3.12",
     "pytest-json-report>=1.5.0",
     "pytest-benchmark>=5.0",  # For performance tests
-    "pytest-xdist>=3.5",  # For parallel test execution
+    
     "respx>=0.21",
     "pandas>=2.0",  # For data analysis handler tests
 


### PR DESCRIPTION
CI shards already parallelize across 6 jobs. Remove xdist to eliminate cross-contamination failures.