### PR TITLE
fix: release workflow timeout

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,6 +43,7 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
 
@@ -71,13 +72,13 @@ jobs:
         run: |
           pip install --force-reinstall --no-deps -e .
           pip install -e ".[dev,api]"
-          pip install scipy
+          pip install scipy pytest-timeout
           pip uninstall -y victor || true
           python -c "from victor import Agent, __version__; print(f'✓ Agent import works (victor {__version__})')"
 
       - name: Run tests
         run: |
-          pytest tests/unit -v --tb=short -m "not slow and not integration"
+          pytest tests/unit -v --tb=short -m "not slow and not integration" --timeout=120
 
       - name: Run linting
         run: |


### PR DESCRIPTION
Add 30min job timeout and 120s per-test timeout to prevent hanging