### PR TITLE
fix: skip external compatibility dispatch without PAT

### DIFF
--- a/.github/workflows/external-vertical-compat.yml
+++ b/.github/workflows/external-vertical-compat.yml
@@ -14,6 +14,8 @@ jobs:
     name: Dispatch Compatibility Checks
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    env:
+      HAS_EXTERNAL_VERTICAL_PAT: ${{ secrets.EXTERNAL_VERTICAL_PAT != '' }}
 
     strategy:
       fail-fast: false
@@ -34,23 +36,34 @@ jobs:
 
     steps:
       - name: Dispatch core-compat-check to ${{ matrix.name }}
-        uses: peter-evans/repository-dispatch@v3
-        continue-on-error: false
-        with:
-          token: ${{ secrets.EXTERNAL_VERTICAL_PAT }}
-          repository: ${{ matrix.repo }}
-          event-type: core-compat-check
-          client-payload: |
-            {
-              "victor_ref": "${{ github.sha }}",
-              "victor_branch": "${{ github.ref_name }}",
-              "triggered_by": "${{ github.event_name }}",
-              "run_url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-            }
+        if: env.HAS_EXTERNAL_VERTICAL_PAT == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.EXTERNAL_VERTICAL_PAT }}
+          TARGET_REPO: ${{ matrix.repo }}
+        run: |
+          gh api \
+            --method POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "repos/${TARGET_REPO}/dispatches" \
+            -f event_type='core-compat-check' \
+            -F client_payload[victor_ref]='${{ github.sha }}' \
+            -F client_payload[victor_branch]='${{ github.ref_name }}' \
+            -F client_payload[triggered_by]='${{ github.event_name }}' \
+            -F client_payload[run_url]='${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+      - name: Skip dispatch when PAT is unavailable
+        if: env.HAS_EXTERNAL_VERTICAL_PAT != 'true'
+        run: |
+          echo "Skipping dispatch to ${{ matrix.repo }} because EXTERNAL_VERTICAL_PAT is not configured."
 
       - name: Log dispatch
         run: |
-          echo "Dispatched core-compat-check to ${{ matrix.repo }}"
+          if [ "${HAS_EXTERNAL_VERTICAL_PAT}" = "true" ]; then
+            echo "Dispatched core-compat-check to ${{ matrix.repo }}"
+          else
+            echo "Skipped core-compat-check for ${{ matrix.repo }} (missing EXTERNAL_VERTICAL_PAT)"
+          fi
           echo "  Victor ref: ${{ github.sha }}"
           echo "  Victor branch: ${{ github.ref_name }}"
 
@@ -59,22 +72,32 @@ jobs:
     runs-on: ubuntu-latest
     needs: dispatch-compat-checks
     if: always()
+    env:
+      HAS_EXTERNAL_VERTICAL_PAT: ${{ secrets.EXTERNAL_VERTICAL_PAT != '' }}
 
     steps:
       - name: Summary
         run: |
           echo "## External Vertical Compatibility Dispatch" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "Dispatched \`core-compat-check\` events to external vertical repos." >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "Each external repo runs its test suite against this commit." >> $GITHUB_STEP_SUMMARY
-          echo "Results are **blocking** — dispatch failures indicate a PAT or repo issue." >> $GITHUB_STEP_SUMMARY
+          if [ "${HAS_EXTERNAL_VERTICAL_PAT}" = "true" ]; then
+            status="Dispatched"
+            echo "Dispatched \`core-compat-check\` events to external vertical repos." >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "Each external repo runs its test suite against this commit." >> $GITHUB_STEP_SUMMARY
+            echo "Results are **blocking** when dispatching is enabled." >> $GITHUB_STEP_SUMMARY
+          else
+            status="Skipped (missing EXTERNAL_VERTICAL_PAT)"
+            echo "Skipped external dispatch because \`EXTERNAL_VERTICAL_PAT\` is not configured." >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "This workflow is informational until cross-repo dispatch credentials are configured." >> $GITHUB_STEP_SUMMARY
+          fi
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "| Repo | Status |" >> $GITHUB_STEP_SUMMARY
           echo "|------|--------|" >> $GITHUB_STEP_SUMMARY
-          echo "| victor-coding | Dispatched |" >> $GITHUB_STEP_SUMMARY
-          echo "| victor-devops | Dispatched |" >> $GITHUB_STEP_SUMMARY
-          echo "| victor-rag | Dispatched |" >> $GITHUB_STEP_SUMMARY
-          echo "| victor-dataanalysis | Dispatched |" >> $GITHUB_STEP_SUMMARY
-          echo "| victor-research | Dispatched |" >> $GITHUB_STEP_SUMMARY
-          echo "| victor-invest | Dispatched |" >> $GITHUB_STEP_SUMMARY
+          echo "| victor-coding | ${status} |" >> $GITHUB_STEP_SUMMARY
+          echo "| victor-devops | ${status} |" >> $GITHUB_STEP_SUMMARY
+          echo "| victor-rag | ${status} |" >> $GITHUB_STEP_SUMMARY
+          echo "| victor-dataanalysis | ${status} |" >> $GITHUB_STEP_SUMMARY
+          echo "| victor-research | ${status} |" >> $GITHUB_STEP_SUMMARY
+          echo "| victor-invest | ${status} |" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary
- replace the third-party repository-dispatch action with a direct gh api call
- skip external vertical dispatch cleanly when EXTERNAL_VERTICAL_PAT is not configured
- update the workflow summary so skipped dispatches are reported explicitly instead of failing develop

## Validation
- python -c "from pathlib import Path; import yaml; yaml.safe_load(Path('.github/workflows/external-vertical-compat.yml').read_text())"
- python scripts/ci/repo_hygiene_check.py