### PR TITLE
fix: make graph/code-search/init/streaming robust on large polyglot repos

### DIFF
--- a/tests/unit/agent/services/test_overlap_repetition.py
+++ b/tests/unit/agent/services/test_overlap_repetition.py
@@ -1,0 +1,71 @@
+# Copyright 2025 Vijaykumar Singh <singhvjd@gmail.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Word-overlap repetition decision used by the streaming executor.
+
+Regression for the spin where the same narration repeated many turns without
+breaking: a moderate-overlap turn used to decay the counter, so an oscillating
+loop never reached the force-completion threshold.
+"""
+
+from victor.agent.services.chat_stream_executor import _evaluate_overlap_repetition
+
+
+def test_near_duplicate_forces_on_first_occurrence() -> None:
+    count, action = _evaluate_overlap_repetition(0.9, repetition_count=0)
+    assert action == "near_duplicate"
+    assert count == 1
+
+
+def test_two_high_overlap_turns_force_completion() -> None:
+    count, action = _evaluate_overlap_repetition(0.6, repetition_count=0)
+    assert action == "accumulating"
+    assert count == 1
+
+    count, action = _evaluate_overlap_repetition(0.6, repetition_count=count)
+    assert action == "high_overlap"
+    assert count == 2
+
+
+def test_moderate_overlap_holds_count_without_decay() -> None:
+    # The key fix: a 0.3 < overlap <= 0.5 turn between two high-overlap turns
+    # must NOT reset/decay the accumulated spin signal.
+    count, action = _evaluate_overlap_repetition(0.6, repetition_count=0)
+    assert (count, action) == (1, "accumulating")
+
+    count, action = _evaluate_overlap_repetition(0.45, repetition_count=count)
+    assert action == "hold"
+    assert count == 1  # held, not decayed
+
+    count, action = _evaluate_overlap_repetition(0.6, repetition_count=count)
+    assert action == "high_overlap"
+    assert count == 2
+
+
+def test_distinct_content_resets_count() -> None:
+    count, action = _evaluate_overlap_repetition(0.2, repetition_count=3)
+    assert action == "reset"
+    assert count == 0
+
+
+def test_oscillating_loop_eventually_breaks() -> None:
+    """A loop alternating 0.55 / 0.4 overlap converges instead of spinning forever."""
+    count = 0
+    forced_at = None
+    for i, overlap in enumerate([0.55, 0.4, 0.55, 0.4, 0.55]):
+        count, action = _evaluate_overlap_repetition(overlap, count)
+        if action in ("near_duplicate", "high_overlap"):
+            forced_at = i
+            break
+    assert forced_at is not None, "oscillating loop should break, not spin forever"

--- a/tests/unit/core/test_project_db_root_resolution.py
+++ b/tests/unit/core/test_project_db_root_resolution.py
@@ -1,0 +1,119 @@
+# Copyright 2025 Vijaykumar Singh <singhvjd@gmail.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Project database root resolution (walk-up to the owning project).
+
+Regression coverage for the bug where querying a *subdirectory* (e.g. graph
+analytics scoped to ``src/network``) resolved to a fresh empty
+``src/network/.victor/project.db`` instead of the repository's real
+``<root>/.victor/project.db`` — which made broad graph modes report the database
+as "unavailable" and littered stray ``.victor/`` directories through the tree.
+"""
+
+from pathlib import Path
+
+from victor.core.database import (
+    _normalize_project_database_paths,
+    resolve_project_db_root,
+)
+
+
+def _fresh_dir(tmp_path: Path, name: str) -> Path:
+    """A unique directory under tmp_path, free of autouse-fixture artifacts."""
+    d = (tmp_path / name).resolve()
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+def _make_indexed_repo(root: Path) -> None:
+    (root / ".git").mkdir(exist_ok=True)
+    (root / ".victor").mkdir(exist_ok=True)
+    (root / ".victor" / "project.db").write_text("")
+
+
+def test_subdirectory_resolves_to_repo_project_db(tmp_path: Path) -> None:
+    root = _fresh_dir(tmp_path, "repo")
+    _make_indexed_repo(root)
+    sub = root / "src" / "network"
+    sub.mkdir(parents=True)
+
+    project_root, project_dir, db_path = _normalize_project_database_paths(sub)
+
+    assert project_root == root
+    assert project_dir == root / ".victor"
+    assert db_path == root / ".victor" / "project.db"
+    assert resolve_project_db_root(sub) == root
+
+
+def test_subdirectory_lookup_creates_no_stray_victor_dir(tmp_path: Path) -> None:
+    root = _fresh_dir(tmp_path, "repo")
+    _make_indexed_repo(root)
+    sub = root / "src" / "services"
+    sub.mkdir(parents=True)
+
+    _normalize_project_database_paths(sub)
+
+    assert not (sub / ".victor").exists()
+
+
+def test_root_with_project_db_resolves_to_itself(tmp_path: Path) -> None:
+    root = _fresh_dir(tmp_path, "repo")
+    _make_indexed_repo(root)
+
+    project_root, _project_dir, db_path = _normalize_project_database_paths(root)
+
+    assert project_root == root
+    assert db_path == root / ".victor" / "project.db"
+
+
+def test_fresh_repo_initializes_in_place(tmp_path: Path) -> None:
+    """A not-yet-indexed repo still initializes its DB at the requested path."""
+    root = _fresh_dir(tmp_path, "repo")
+    (root / ".git").mkdir()  # repo boundary, but no project.db yet
+    sub = root / "a" / "b"
+    sub.mkdir(parents=True)
+
+    project_root, _project_dir, db_path = _normalize_project_database_paths(sub)
+
+    # Bounded by .git: no ancestor project.db, so it stays at the requested path.
+    assert project_root == sub
+    assert db_path == sub / ".victor" / "project.db"
+
+
+def test_walk_up_stops_at_git_boundary(tmp_path: Path) -> None:
+    """An ancestor project.db above the git root must not be adopted."""
+    outer = _fresh_dir(tmp_path, "outer")
+    (outer / ".victor").mkdir()
+    (outer / ".victor" / "project.db").write_text("")  # unrelated outer project
+
+    repo = outer / "repo"
+    repo.mkdir()
+    (repo / ".git").mkdir()  # inner repo boundary, no project.db
+    sub = repo / "src"
+    sub.mkdir()
+
+    project_root, _project_dir, _db_path = _normalize_project_database_paths(sub)
+
+    # Must not cross the inner .git boundary up into ``outer``.
+    assert project_root == sub
+
+
+def test_explicit_db_path_is_respected(tmp_path: Path) -> None:
+    db_file = _fresh_dir(tmp_path, "custom") / "project.db"
+
+    project_root, project_dir, db_path = _normalize_project_database_paths(db_file)
+
+    assert db_path == db_file
+    assert project_dir == db_file.parent
+    assert project_root == db_file.parent.parent

--- a/tests/unit/framework/test_init_synthesizer.py
+++ b/tests/unit/framework/test_init_synthesizer.py
@@ -17,7 +17,47 @@ from victor.framework.init_synthesizer import (
     SYNTHESIS_RULES,
     SYNTHESIS_PROMPT,
     _build_synthesis_prompt,
+    _classify_init_failure,
+    _init_provider_timeout,
 )
+
+
+class TestInitProviderTimeout:
+    """Adaptive init-synthesis timeout resolution."""
+
+    def test_local_provider_gets_large_budget(self):
+        assert _init_provider_timeout("ollama") == 600
+
+    def test_cloud_provider_gets_default(self):
+        assert _init_provider_timeout("zai") == 300
+
+    def test_never_reduces_configured_timeout(self):
+        assert _init_provider_timeout("zai", configured=900) == 900
+        assert _init_provider_timeout("ollama", configured=120) == 600
+
+    def test_env_override_wins(self, monkeypatch):
+        monkeypatch.setenv("VICTOR_INIT_SYNTH_TIMEOUT", "42")
+        assert _init_provider_timeout("ollama", configured=900) == 42
+
+    def test_invalid_env_override_ignored(self, monkeypatch):
+        monkeypatch.setenv("VICTOR_INIT_SYNTH_TIMEOUT", "not-a-number")
+        assert _init_provider_timeout("zai") == 300
+
+
+class TestClassifyInitFailure:
+    """Failure categorization for actionable template-fallback logging."""
+
+    def test_timeout(self):
+        assert _classify_init_failure(Exception("Request timed out after 300s")) == "timeout"
+
+    def test_connection(self):
+        assert _classify_init_failure(OSError("connection refused")) == "connection"
+
+    def test_empty_output(self):
+        assert _classify_init_failure(Exception("returned empty content")) == "empty_output"
+
+    def test_other(self):
+        assert _classify_init_failure(ValueError("weird")) == "ValueError"
 
 
 @pytest.fixture(autouse=True)
@@ -223,7 +263,9 @@ class TestInitSynthesizer:
 
         assert result == "# init"
         assert mock_provider.chat.call_args.kwargs["model"] == "profile-default"
-        mock_create.assert_called_once_with("ollama", timeout=120, max_retries=0)
+        # Local providers (ollama) get a generous init-synthesis timeout so a
+        # large local model isn't cut off mid-generation; retries stay at 0.
+        mock_create.assert_called_once_with("ollama", timeout=600, max_retries=0)
 
     def test_resolve_provider_selection_prefers_default_profile(self):
         """Init synthesis should honor the default profile before provider defaults."""

--- a/tests/unit/tools/test_code_search_tool.py
+++ b/tests/unit/tools/test_code_search_tool.py
@@ -1951,13 +1951,14 @@ async def test_literal_search_filename_only_timeout_returns_friendly_error(
             filename_only=True,
         )
 
-    assert result == {
-        "success": False,
-        "error": "Filename search timed out after 15s",
-        "results": [],
-        "count": 0,
-        "mode": "filename",
-    }
+    # The filename-search timeout is env-overridable (default 45s) and the error
+    # message names the override knob for very large trees.
+    assert result["success"] is False
+    assert result["results"] == []
+    assert result["count"] == 0
+    assert result["mode"] == "filename"
+    assert result["error"].startswith("Filename search timed out after 45s")
+    assert "VICTOR_TIMEOUT_FILENAME_SEARCH" in result["error"]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/tools/test_graph_centrality_sql.py
+++ b/tests/unit/tools/test_graph_centrality_sql.py
@@ -1,0 +1,157 @@
+# Copyright 2025 Vijaykumar Singh <singhvjd@gmail.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Regression: degree-centrality SQL binding for multi-type edge groups.
+
+The ``patterns``/``centrality`` fast path interpolates the edge-type filter
+twice (outgoing + incoming degree subqueries). Previously the bound parameters
+were supplied only once and in the wrong order, so a multi-type ``edge_group``
+(e.g. ``type_hierarchy`` → INHERITS/IMPLEMENTS/IS_A) raised
+``sqlite3.ProgrammingError: Incorrect number of bindings supplied``.
+"""
+
+from pathlib import Path
+
+from victor.core.database import get_project_database, reset_project_database
+from victor.tools.graph_tool import (
+    _build_cheap_overview_from_project_store,
+    _build_degree_centrality_from_project_store,
+)
+
+
+def _seed_graph(root: Path) -> None:
+    db = get_project_database(root)
+    conn = db.get_connection()
+    conn.executescript("""
+        CREATE TABLE IF NOT EXISTS graph_node (
+            node_id TEXT PRIMARY KEY, type TEXT NOT NULL, name TEXT NOT NULL,
+            file TEXT NOT NULL, line INTEGER
+        );
+        CREATE TABLE IF NOT EXISTS graph_edge (
+            src TEXT NOT NULL, dst TEXT NOT NULL, type TEXT NOT NULL,
+            PRIMARY KEY (src, dst, type)
+        );
+        """)
+    nodes = [
+        ("Base", "class", "Base", "src/lib.rs", 1),
+        ("Mid", "class", "Mid", "src/mid.rs", 2),
+        ("Leaf", "class", "Leaf", "src/leaf.rs", 3),
+        ("helper", "function", "helper", "src/util.rs", 4),
+    ]
+    conn.executemany(
+        "INSERT INTO graph_node (node_id, type, name, file, line) VALUES (?, ?, ?, ?, ?)",
+        nodes,
+    )
+    edges = [
+        ("Mid", "Base", "INHERITS"),
+        ("Leaf", "Mid", "INHERITS"),
+        ("Leaf", "Base", "IMPLEMENTS"),
+        ("Mid", "Base", "IS_A"),
+        ("helper", "Leaf", "CALLS"),
+    ]
+    conn.executemany("INSERT INTO graph_edge (src, dst, type) VALUES (?, ?, ?)", edges)
+    conn.commit()
+
+
+def test_degree_centrality_multi_edge_and_node_types(tmp_path: Path) -> None:
+    root = (tmp_path / "repo").resolve()
+    root.mkdir()
+    (root / ".victor").mkdir()
+    try:
+        _seed_graph(root)
+
+        # type_hierarchy = 3 edge types; class/function = 2 node types. The old
+        # code supplied 3 + 2 + 1 = 6 bindings for a query needing 2*3 + 2 + 1 = 9.
+        result = _build_degree_centrality_from_project_store(
+            root,
+            top_k=10,
+            edge_types=["INHERITS", "IMPLEMENTS", "IS_A"],
+            node_types={"class", "function"},
+        )
+
+        nodes = result["nodes"]
+        assert nodes, "expected ranked nodes, not an empty/raising result"
+        by_name = {n["name"]: n for n in nodes}
+        # Base is the inheritance hub: 3 incoming hierarchy edges, 0 outgoing.
+        assert by_name["Base"]["in_degree"] == 3
+        assert by_name["Base"]["out_degree"] == 0
+        # CALLS is excluded by the edge-type filter, so helper has degree 0.
+        assert by_name["helper"]["degree"] == 0
+    finally:
+        reset_project_database(root)
+
+
+def _seed_two_subtrees(root: Path) -> None:
+    db = get_project_database(root)
+    conn = db.get_connection()
+    conn.executescript("""
+        CREATE TABLE IF NOT EXISTS graph_node (
+            node_id TEXT PRIMARY KEY, type TEXT NOT NULL, name TEXT NOT NULL,
+            file TEXT NOT NULL, line INTEGER
+        );
+        CREATE TABLE IF NOT EXISTS graph_edge (
+            src TEXT NOT NULL, dst TEXT NOT NULL, type TEXT NOT NULL,
+            PRIMARY KEY (src, dst, type)
+        );
+        """)
+    nodes = [
+        ("NetA", "class", "NetA", "src/network/a.rs", 1),
+        ("NetB", "class", "NetB", "src/network/b.rs", 2),
+        ("StoreA", "class", "StoreA", "src/storage/a.rs", 3),
+    ]
+    conn.executemany(
+        "INSERT INTO graph_node (node_id, type, name, file, line) VALUES (?, ?, ?, ?, ?)",
+        nodes,
+    )
+    conn.executemany(
+        "INSERT INTO graph_edge (src, dst, type) VALUES (?, ?, ?)",
+        [("NetA", "NetB", "CALLS"), ("StoreA", "NetA", "CALLS")],
+    )
+    conn.commit()
+
+
+def test_overview_scopes_to_requested_subdirectory(tmp_path: Path) -> None:
+    root = (tmp_path / "repo3").resolve()
+    root.mkdir()
+    (root / ".victor").mkdir()
+    (root / "src" / "network").mkdir(parents=True)
+    try:
+        _seed_two_subtrees(root)
+
+        scoped = _build_cheap_overview_from_project_store(root / "src" / "network", top_k=25)
+        files = {m["file"] for m in scoped["important_modules"]}
+        assert files == {"src/network/a.rs", "src/network/b.rs"}
+        assert all("storage" not in f for f in files)
+
+        # Whole-repo request still sees everything.
+        full = _build_cheap_overview_from_project_store(root, top_k=25)
+        full_files = {m["file"] for m in full["important_modules"]}
+        assert "src/storage/a.rs" in full_files
+    finally:
+        reset_project_database(root)
+
+
+def test_degree_centrality_no_filters(tmp_path: Path) -> None:
+    """Unfiltered path still binds correctly (only the LIMIT placeholder)."""
+    root = (tmp_path / "repo2").resolve()
+    root.mkdir()
+    (root / ".victor").mkdir()
+    try:
+        _seed_graph(root)
+        result = _build_degree_centrality_from_project_store(
+            root, top_k=10, edge_types=None, node_types=None
+        )
+        assert result["nodes"]
+    finally:
+        reset_project_database(root)

--- a/tests/unit/tools/test_graph_node_resolution.py
+++ b/tests/unit/tools/test_graph_node_resolution.py
@@ -1,0 +1,63 @@
+# Copyright 2025 Vijaykumar Singh <singhvjd@gmail.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Dotted-module node resolution against path-based (e.g. Rust) file nodes.
+
+Regression for "Could not resolve graph node 'src.network.multi_server'" — the
+model addressed files with Python-style dotted paths while the graph stored
+``src/network/multi_server.rs`` file nodes.
+"""
+
+from victor.storage.graph.protocol import GraphNode
+from victor.tools.graph_tool import GraphAnalyzer, _module_path_stem
+
+
+def _analyzer() -> GraphAnalyzer:
+    analyzer = GraphAnalyzer()
+    for node_id, type_, name, file in [
+        ("n1", "file", "multi_server.rs", "src/network/multi_server.rs"),
+        ("n2", "file", "mod.rs", "src/network/mod.rs"),
+        ("n3", "file", "lib.rs", "src/lib.rs"),
+        ("n4", "struct", "MultiServer", "src/network/multi_server.rs"),
+    ]:
+        analyzer.add_node(GraphNode(node_id=node_id, type=type_, name=name, file=file))
+    return analyzer
+
+
+def test_module_path_stem_strips_extension_and_index_files() -> None:
+    assert _module_path_stem("src/network/multi_server.rs") == "src/network/multi_server"
+    assert _module_path_stem("src/network/mod.rs") == "src/network"
+    assert _module_path_stem("src/lib.rs") == "src/lib"
+    assert _module_path_stem("a/b/__init__.py") == "a/b"
+
+
+def test_dotted_file_reference_resolves() -> None:
+    analyzer = _analyzer()
+    assert analyzer.resolve_node_id("src.network.multi_server") in {"n1", "n4"}
+
+
+def test_dotted_module_dir_resolves_via_index_file() -> None:
+    analyzer = _analyzer()
+    # src.network -> src/network/mod.rs
+    assert analyzer.resolve_node_id("src.network") == "n2"
+
+
+def test_dotted_lib_reference_resolves() -> None:
+    analyzer = _analyzer()
+    assert analyzer.resolve_node_id("src.lib") == "n3"
+
+
+def test_unrelated_dotted_reference_still_unresolved() -> None:
+    analyzer = _analyzer()
+    assert analyzer.resolve_node_id("totally.unknown.thing") is None

--- a/tests/unit/tools/test_index_build_timeout.py
+++ b/tests/unit/tools/test_index_build_timeout.py
@@ -1,0 +1,50 @@
+# Copyright 2025 Vijaykumar Singh <singhvjd@gmail.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Polyglot index-build timeout heuristic.
+
+Regression for the 60s timeout that always fired on large non-Python repos:
+the heuristic previously counted only ``.py`` files, so a Rust codebase scored
+the bare 60s base timeout regardless of size.
+"""
+
+from pathlib import Path
+
+from victor.tools.code_search_tool import _calculate_index_build_timeout
+
+
+def test_rust_only_repo_scales_above_base_timeout(tmp_path: Path) -> None:
+    src = tmp_path / "src"
+    src.mkdir()
+    for i in range(120):
+        (src / f"mod_{i}.rs").write_text("pub fn f() {}\n" * 40)
+
+    timeout = _calculate_index_build_timeout(tmp_path)
+
+    # 120 source files * 5s = 600s file term alone; must exceed the 60s base.
+    assert timeout > 60.0
+
+
+def test_empty_repo_uses_base_timeout(tmp_path: Path) -> None:
+    assert _calculate_index_build_timeout(tmp_path) == 60.0
+
+
+def test_victor_cache_is_not_counted(tmp_path: Path) -> None:
+    """Files under .victor (caches) must not inflate the estimate."""
+    cache = tmp_path / ".victor" / "swe_bench_cache"
+    cache.mkdir(parents=True)
+    for i in range(200):
+        (cache / f"junk_{i}.py").write_text("x = 1\n")
+
+    assert _calculate_index_build_timeout(tmp_path) == 60.0

--- a/tests/unit/tools/test_index_rebuild_singleflight.py
+++ b/tests/unit/tools/test_index_rebuild_singleflight.py
@@ -1,0 +1,92 @@
+# Copyright 2025 Vijaykumar Singh <singhvjd@gmail.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Single-flight background index rebuilds + filename-search timeout override.
+
+Regression for the cascade where every stale ``code_search`` call spawned a new
+fire-and-forget rebuild, so concurrent rebuilds thrashed the embeddings store
+and re-triggered probe timeouts.
+"""
+
+import asyncio
+
+from victor.tools.code_search_tool import (
+    _filename_search_timeout,
+    _INFLIGHT_INDEX_REBUILDS,
+    _spawn_index_rebuild_once,
+)
+
+
+async def test_rebuild_is_deduplicated_while_in_flight() -> None:
+    _INFLIGHT_INDEX_REBUILDS.clear()
+    started = 0
+    gate = asyncio.Event()
+
+    async def _rebuild() -> None:
+        nonlocal started
+        started += 1
+        await gate.wait()
+
+    t1 = _spawn_index_rebuild_once("root-a", _rebuild)
+    t2 = _spawn_index_rebuild_once("root-a", _rebuild)
+
+    # Both calls share one in-flight task; the factory ran only once.
+    assert t1 is t2
+    await asyncio.sleep(0)  # let the task start
+    assert started == 1
+    assert "root-a" in _INFLIGHT_INDEX_REBUILDS
+
+    gate.set()
+    await t1
+    await asyncio.sleep(0)  # allow done-callback to clear the registry
+    assert "root-a" not in _INFLIGHT_INDEX_REBUILDS
+
+
+async def test_distinct_roots_run_independently() -> None:
+    _INFLIGHT_INDEX_REBUILDS.clear()
+    gate = asyncio.Event()
+
+    async def _rebuild() -> None:
+        await gate.wait()
+
+    t_a = _spawn_index_rebuild_once("root-a", _rebuild)
+    t_b = _spawn_index_rebuild_once("root-b", _rebuild)
+    assert t_a is not t_b
+
+    gate.set()
+    await asyncio.gather(t_a, t_b)
+
+
+async def test_completed_rebuild_allows_respawn() -> None:
+    _INFLIGHT_INDEX_REBUILDS.clear()
+    runs = 0
+
+    async def _rebuild() -> None:
+        nonlocal runs
+        runs += 1
+
+    await _spawn_index_rebuild_once("root-a", _rebuild)
+    await asyncio.sleep(0)
+    # Prior task finished and cleared; a new call spawns a fresh rebuild.
+    await _spawn_index_rebuild_once("root-a", _rebuild)
+    assert runs == 2
+
+
+def test_filename_search_timeout_env_override(monkeypatch) -> None:
+    monkeypatch.delenv("VICTOR_TIMEOUT_FILENAME_SEARCH", raising=False)
+    monkeypatch.delenv("VICTOR_FILENAME_SEARCH_TIMEOUT", raising=False)
+    assert _filename_search_timeout() == 45.0
+
+    monkeypatch.setenv("VICTOR_TIMEOUT_FILENAME_SEARCH", "90")
+    assert _filename_search_timeout() == 90.0

--- a/victor/agent/services/chat_stream_executor.py
+++ b/victor/agent/services/chat_stream_executor.py
@@ -16,7 +16,7 @@ import hashlib
 import logging
 import re
 from types import SimpleNamespace
-from typing import Any, AsyncIterator, List, Optional
+from typing import Any, AsyncIterator, List, Optional, Tuple
 
 from victor.agent.output_deduplicator import OutputDeduplicator
 from victor.agent.services.protocols.streaming_runtime import (
@@ -30,6 +30,30 @@ from victor.framework.runtime_evaluation_policy import RuntimeEvaluationPolicy
 from victor.providers.base import StreamChunk
 
 logger = logging.getLogger(__name__)
+
+
+def _evaluate_overlap_repetition(overlap: float, repetition_count: int) -> Tuple[int, str]:
+    """Decide repetition handling from word-overlap between consecutive turns.
+
+    Returns ``(updated_repetition_count, action)`` where ``action`` is one of:
+      - ``"near_duplicate"`` — ``overlap >= 0.8``: a single strong repeat is
+        enough to force completion (breaks a narration spin immediately).
+      - ``"high_overlap"``  — ``overlap > 0.5`` and the running count has reached
+        2: force completion.
+      - ``"accumulating"``  — ``overlap > 0.5`` but only the first such turn so far.
+      - ``"reset"``         — ``overlap <= 0.3``: genuinely distinct, clear the count.
+      - ``"hold"``          — ``0.3 < overlap <= 0.5``: ambiguous; keep the count
+        without decaying it, so an oscillating loop still converges to the
+        threshold instead of resetting every other turn (the observed bug).
+    """
+    if overlap >= 0.8:
+        return repetition_count + 1, "near_duplicate"
+    if overlap > 0.5:
+        new_count = repetition_count + 1
+        return new_count, ("high_overlap" if new_count >= 2 else "accumulating")
+    if overlap <= 0.3:
+        return 0, "reset"
+    return repetition_count, "hold"
 
 
 def _extract_required_files_from_prompt(user_message: str) -> List[str]:
@@ -1182,9 +1206,21 @@ class StreamingChatExecutor:
                     curr_words = set(curr_norm.split())
                     if prev_words and curr_words:
                         overlap = len(prev_words & curr_words) / len(prev_words | curr_words)
-                        # P0 FIX: Lower threshold from 0.6 to 0.5 for earlier detection
-                        if overlap > 0.5:
-                            self._repetition_count += 1
+                        self._repetition_count, action = _evaluate_overlap_repetition(
+                            overlap, self._repetition_count
+                        )
+                        if action == "near_duplicate":
+                            # Near-duplicate narration (e.g. the same "Let me drill
+                            # into…" sentence repeated). A single strong repeat
+                            # breaks the spin — don't wait for a second.
+                            logger.warning(
+                                "[content-repetition] Near-duplicate content "
+                                "(overlap=%.1f%%, content_len=%s) — forcing completion "
+                                "to break narration spin.",
+                                overlap * 100,
+                                len(full_content),
+                            )
+                        elif action in ("high_overlap", "accumulating"):
                             logger.warning(
                                 "[content-repetition] High content overlap detected "
                                 "(overlap=%.1f%%, consecutive=%s, content_len=%s)",
@@ -1192,25 +1228,21 @@ class StreamingChatExecutor:
                                 self._repetition_count,
                                 len(full_content),
                             )
-                            # P0 FIX: Force completion after 2 consecutive high-overlap (not 3)
-                            if self._repetition_count >= 2:
+
+                        if action in ("near_duplicate", "high_overlap"):
+                            if action == "high_overlap":
                                 logger.warning(
-                                    "[content-repetition] 2+ consecutive high-overlap iterations — "
+                                    "[content-repetition] 2+ high-overlap iterations — "
                                     "forcing completion immediately."
                                 )
-                                stream_ctx.force_completion = True
-                                stream_ctx.skip_continuation = True
-                                yield orch._chunk_generator.generate_content_chunk(
-                                    "\n\n[Content repetition detected — stopping to prevent "
-                                    "infinite output loop.]",
-                                    is_final=True,
-                                )
-                                return
-                        elif overlap > 0.3:
-                            # Decrease count when overlap is moderate (reduced from 0.4)
-                            self._repetition_count = max(0, self._repetition_count - 1)
-                        else:
-                            self._repetition_count = 0
+                            stream_ctx.force_completion = True
+                            stream_ctx.skip_continuation = True
+                            yield orch._chunk_generator.generate_content_chunk(
+                                "\n\n[Content repetition detected — stopping to prevent "
+                                "infinite output loop.]",
+                                is_final=True,
+                            )
+                            return
                 else:
                     self._repetition_count = 0
 

--- a/victor/agent/services/chat_stream_helpers.py
+++ b/victor/agent/services/chat_stream_helpers.py
@@ -1361,6 +1361,11 @@ class ChatStreamHelperMixin:
                         now = time.monotonic()
                         wait_overrun_seconds = max(0.0, now - wait_started_at - heartbeat_interval)
                         if wait_overrun_seconds > loop_stall_grace:
+                            # The heartbeat wait overran by more than the grace
+                            # window: the local asyncio event loop was blocked
+                            # (host-side GC/CPU), not the provider. Attribute it to
+                            # the host and reset the timer so a responsive provider
+                            # (including cloud) is not penalized for local blocking.
                             self._record_provider_status_event(
                                 stream_ctx,
                                 "local_runtime_stall",
@@ -1369,8 +1374,9 @@ class ChatStreamHelperMixin:
                                 model=getattr(orch, "model", None),
                             )
                             logger.warning(
-                                "[provider-stream] Local runtime was unavailable for %.1fs "
-                                "while waiting on provider; resetting provider stall timer",
+                                "[provider-stream] Local event loop blocked for %.1fs "
+                                "(host-side GC/CPU, not the provider); not charging it "
+                                "against the provider stall timer",
                                 wait_overrun_seconds,
                             )
                             waiting_since = now

--- a/victor/core/database.py
+++ b/victor/core/database.py
@@ -441,6 +441,36 @@ class DatabaseConsolidator:
             target_conn.close()
 
 
+def _find_existing_project_dir(start: Path) -> Optional[Path]:
+    """Walk up from ``start`` to the nearest ancestor holding ``.victor/project.db``.
+
+    A project owns a single ``.victor/project.db`` at its root. Resolving a
+    subdirectory (e.g. ``src/network``) must therefore reuse the repository's
+    project database rather than fabricate a fresh empty one under the subdir.
+
+    Only an *existing* ``project.db`` is matched, so a brand-new project still
+    initializes in place. The search is bounded at the git repository root: it
+    never ascends past a directory that contains ``.git`` without first finding
+    a project database there.
+
+    Args:
+        start: Directory to begin the upward search from (already resolved).
+
+    Returns:
+        The ``.victor`` directory of the owning project, or ``None`` if no
+        existing project database is found within the bound.
+    """
+    for ancestor in (start, *start.parents):
+        victor_dir = ancestor / ".victor"
+        if (victor_dir / "project.db").exists():
+            return victor_dir
+        # Stop at the repository boundary: a subdir of a not-yet-indexed repo
+        # should initialize at the repo root via the caller, not somewhere above.
+        if (ancestor / ".git").exists():
+            break
+    return None
+
+
 def _normalize_project_database_paths(
     project_path: Optional[Path],
 ) -> tuple[Path, Path, Path]:
@@ -457,7 +487,11 @@ def _normalize_project_database_paths(
         project_dir = resolved
         db_path = project_dir / "project.db"
     else:
-        project_dir = resolved / ".victor"
+        # Prefer an existing project DB in an ancestor so subdirectory lookups
+        # resolve to the repository's single project.db instead of creating an
+        # empty DB (and stray ``.victor/`` dir) under the subdirectory.
+        existing = _find_existing_project_dir(resolved)
+        project_dir = existing if existing is not None else resolved / ".victor"
         db_path = project_dir / "project.db"
 
     project_root = project_dir.parent
@@ -1807,6 +1841,24 @@ def get_project_database(project_path: Optional[Path] = None) -> ProjectDatabase
     return _project_databases[project_key]
 
 
+def resolve_project_db_root(project_path: Optional[Path] = None) -> Path:
+    """Resolve the canonical project root that owns the project database.
+
+    Walks up from ``project_path`` (or cwd) to the repository's ``.victor``
+    project, so callers operating on a subdirectory get the single project-level
+    database root rather than the literal subpath. Falls back to the resolved
+    path itself when no existing project database is found (fresh project).
+
+    Args:
+        project_path: A path inside the project (file or directory). Defaults to cwd.
+
+    Returns:
+        The directory that holds (or will hold) ``.victor/project.db``.
+    """
+    project_root, _project_dir, _db_path = _normalize_project_database_paths(project_path)
+    return project_root
+
+
 def reset_database() -> None:
     """Reset the global database instance (for testing)."""
     global _database
@@ -1845,6 +1897,7 @@ __all__ = [
     "ProjectDatabaseManager",
     "get_database",
     "get_project_database",
+    "resolve_project_db_root",
     "reset_database",
     "reset_project_database",
     "reset_all_databases",

--- a/victor/framework/init_synthesizer.py
+++ b/victor/framework/init_synthesizer.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 import logging
+import os
 from typing import TYPE_CHECKING, Any, Optional
 
 if TYPE_CHECKING:
@@ -22,12 +23,60 @@ logger = logging.getLogger(__name__)
 
 INIT_PROVIDER_TIMEOUT_SECONDS = 120
 INIT_PROVIDER_MAX_RETRIES = 0
+
+# Local providers run inference on the box; a large (~20K-char) synthesis prompt
+# to a big local model (e.g. a 31B) needs a generous budget or it times out and
+# silently drops to the template. Cloud providers respond faster.
+_LOCAL_INIT_PROVIDERS = frozenset(
+    {"ollama", "lmstudio", "llamacpp", "llama_cpp", "llama-cpp", "mlx", "vllm"}
+)
+
+
+def _init_provider_timeout(provider_name: str, configured: Optional[float] = None) -> int:
+    """Resolve the init-synthesis request timeout in seconds.
+
+    Honors ``VICTOR_INIT_SYNTH_TIMEOUT`` as an explicit override. Otherwise local
+    providers get a larger budget than cloud providers, and any timeout already
+    configured for the provider is never reduced.
+    """
+    override = os.environ.get("VICTOR_INIT_SYNTH_TIMEOUT")
+    if override:
+        try:
+            return max(1, int(float(override)))
+        except ValueError:
+            logger.debug("[init] Ignoring invalid VICTOR_INIT_SYNTH_TIMEOUT=%r", override)
+
+    base = 600 if (provider_name or "").lower() in _LOCAL_INIT_PROVIDERS else 300
+    if configured is not None:
+        try:
+            return max(int(float(configured)), base)
+        except (TypeError, ValueError):
+            return base
+    return base
+
+
+def _classify_init_failure(error: Exception) -> str:
+    """Return a short, log-friendly category for an init-synthesis failure.
+
+    Distinguishes timeout vs connection vs empty-output vs other so the template
+    fallback is explainable rather than a generic warning.
+    """
+    message = str(error).lower()
+    if "timed out" in message or "timeout" in message:
+        return "timeout"
+    if "connection" in message or "unavailable" in message or isinstance(error, OSError):
+        return "connection"
+    if "empty" in message:
+        return "empty_output"
+    if "rate" in message and "limit" in message:
+        return "rate_limit"
+    return type(error).__name__
+
+
 _ZAI_PROVIDER_ALIASES = frozenset(
     {"zai", "zhipu", "zhipuai", "zai-coding", "zai-coding-plan", "glm-coding"}
 )
-_ZAI_CODING_PROVIDER_ALIASES = frozenset(
-    {"zai-coding", "zai-coding-plan", "glm-coding"}
-)
+_ZAI_CODING_PROVIDER_ALIASES = frozenset({"zai-coding", "zai-coding-plan", "glm-coding"})
 
 
 @dataclass(frozen=True)
@@ -213,6 +262,248 @@ def _trim_to_first_markdown_heading(content: str) -> Optional[str]:
             elif stripped.startswith("##"):
                 return "".join(lines[idx:])
     return None
+
+
+# Signal phrases that indicate the model appended a self-reflective
+# postamble about tool availability instead of just returning the doc.
+# Matched case-insensitively against the trailing prose block only —
+# never against content inside the document body.
+_META_COMMENTARY_SIGNALS = (
+    "no write",
+    "no edit",
+    "no file-write",
+    "write tool",
+    "edit tool",
+    "write/edit",
+    "file-write",
+    "registered toolset",
+    "registered tool set",
+    "tool access",
+    "tool with file-write",
+    "tool with write",
+    "cannot be persisted",
+    "cannot be saved",
+    "cannot write to",
+    "lack the ability",
+    "lack write",
+    "i don't have",
+    "i do not have",
+    "i was unable",
+    "needs to be saved",
+    "save this output",
+    "save the file",
+    "save this file",
+    "ready to be written",
+)
+
+
+# Signal phrases that indicate the model emitted a chat-style recap
+# INSTEAD of the actual init.md document (typically because the agentic
+# loop ran extra iterations after the deliverable was already produced
+# in an earlier turn).
+_LEADING_META_COMMENTARY_SIGNALS = (
+    "already generated",
+    "already wrote",
+    "already written",
+    "already created",
+    "previous turn",
+    "earlier turn",
+    "task is complete",
+    "task complete",
+    "i have generated",
+    "i've generated",
+    "i have created",
+    "i've created",
+    "i have written",
+    "i've written",
+    "verified through tool calls",
+    "all claims verified",
+    "claims verified",
+    "here is the init",
+    "here's the init",
+    "below is the init",
+    "writing the init.md",
+    "let me write",
+    "i'll write",
+    "i will write",
+    "i'll generate",
+    "i will generate",
+    "now i'll",
+    "now i will",
+    "generated `.victor/init.md`",
+    "generated .victor/init.md",
+)
+
+
+def _is_numbered_list_item(stripped: str) -> bool:
+    """Return True if ``stripped`` starts with ``N. `` / ``NN. `` / ``NNN. ``."""
+    dot_idx = stripped.find(". ")
+    if dot_idx < 1 or dot_idx > 3:
+        return False
+    return stripped[:dot_idx].isdigit()
+
+
+def _strip_leading_meta_commentary(content: str) -> str:
+    """Trim a leading self-reflective preamble before the document body.
+
+    Observed leak (2026-05-28): the agentic synthesis loop ran extra
+    iterations after the model had already produced the real init.md in
+    an earlier turn. The final assistant message — which is what gets
+    persisted — was a chat-style recap like::
+
+        The init.md document was already generated and output in my
+        previous turn. The task is complete.
+
+        Generated `.victor/init.md` with all claims verified through
+        tool calls:
+
+        1. **Cargo.toml** — verified version `0.2.0`, ...
+        2. **Makefile** — verified all build/test/benchmark commands
+        ...
+
+    Because the recap has no markdown headings,
+    ``_trim_to_first_markdown_heading`` can't find a trim point and the
+    recap gets persisted as the saved file.
+
+    Strategy: walk forward over leading paragraphs (separated by blank
+    lines). Drop a paragraph if it is plain prose AND contains any
+    leading-meta signal phrase. After dropping >=1 prose paragraph,
+    also drop a directly-following numbered list where every item
+    matches a "verification" pattern. Stops at the first markdown
+    heading or non-meta content paragraph.
+
+    Conservative on purpose: only trims LEADING content, never anything
+    after real document structure has started.
+    """
+    if not content:
+        return content
+    lines = content.splitlines()
+    trimmed_any = False
+    while True:
+        # Drop leading blank lines.
+        while lines and not lines[0].strip():
+            lines.pop(0)
+        if not lines:
+            break
+        # If we hit a markdown heading, the document body has started.
+        first_stripped = lines[0].lstrip()
+        if first_stripped.startswith("#"):
+            break
+        # Find the end of the first paragraph (next blank line, or EOF).
+        para_end = len(lines)
+        for idx in range(len(lines)):
+            if not lines[idx].strip():
+                para_end = idx
+                break
+        paragraph_lines = lines[:para_end]
+        non_blank_lines = [ln for ln in paragraph_lines if ln.strip()]
+        if not non_blank_lines:
+            break
+        # Case 1: a numbered list (e.g. "1. **Cargo.toml** — verified ...").
+        # Only treated as recap when we've already stripped a prose
+        # paragraph above it AND every item looks like a verification
+        # entry. Otherwise it's real content (numbered list of facts).
+        if all(_is_numbered_list_item(ln.lstrip()) for ln in non_blank_lines):
+            if trimmed_any and all(
+                ("verified" in ln.lower() or " — " in ln or " - " in ln) for ln in non_blank_lines
+            ):
+                del lines[:para_end]
+                trimmed_any = True
+                continue
+            break
+        # Case 2: plain prose paragraph. Reject if any line has markdown
+        # structure (heading, list, table, blockquote, code fence).
+        if any(
+            ln.lstrip().startswith(("#", "- ", "* ", "+ ", "> ", "| ", "```"))
+            for ln in paragraph_lines
+        ):
+            break
+        lowered = "\n".join(paragraph_lines).lower()
+        if not any(sig in lowered for sig in _LEADING_META_COMMENTARY_SIGNALS):
+            break
+        del lines[:para_end]
+        trimmed_any = True
+    result = "\n".join(lines)
+    if trimmed_any and content.endswith("\n") and not result.endswith("\n"):
+        result += "\n"
+    return result
+
+
+def _strip_trailing_meta_commentary(content: str) -> str:
+    """Trim a trailing self-reflective paragraph about tool availability.
+
+    Observed leak (2026-05-27): the synthesis agent emitted the full
+    init.md, then appended a paragraph like "No write/edit tool
+    available in the registered toolset — the file content above is
+    ready to be written..." which got persisted verbatim into the saved
+    file because nothing in the cleanup chain looks at the tail.
+
+    Strategy: walk from the end of the document backward over blank
+    lines and a single trailing paragraph. If that paragraph is plain
+    prose (no markdown structure markers — no leading ``#``, ``-``,
+    ``*``, ``|``, ``>``, ``    `` code indent, no fence) and contains
+    any of the meta-commentary signal phrases, trim it plus its
+    leading separator blank lines. Repeat for stacked paragraphs.
+
+    Conservative on purpose: only trims trailing PROSE, never lines
+    that look like document content. A user-written ``## Tool
+    Availability`` section with prose underneath stays intact because
+    the trim stops at the preceding heading.
+    """
+    if not content:
+        return content
+    lines = content.splitlines()
+    trimmed_any = False
+    while True:
+        # Drop trailing blanks
+        while lines and not lines[-1].strip():
+            lines.pop()
+        if not lines:
+            break
+        # Find the start of the trailing paragraph (back to a blank
+        # line or to a markdown-structure line — whichever comes first).
+        para_start = len(lines)
+        for idx in range(len(lines) - 1, -1, -1):
+            line = lines[idx]
+            stripped = line.lstrip()
+            if not stripped:
+                para_start = idx + 1
+                break
+            # Hit a markdown structure line — paragraph starts after it.
+            if (
+                stripped.startswith("#")
+                or stripped.startswith("- ")
+                or stripped.startswith("* ")
+                or stripped.startswith("+ ")
+                or stripped.startswith("> ")
+                or stripped.startswith("| ")
+                or stripped.startswith("|-")
+                or stripped.startswith("```")
+                or (len(line) >= 4 and line[:4] == "    ")
+                or (stripped[:2].isdigit() and ". " in stripped[:5])
+            ):
+                para_start = idx + 1
+                break
+            para_start = idx
+        if para_start >= len(lines):
+            # No trailing prose paragraph found.
+            break
+        paragraph = "\n".join(lines[para_start:])
+        # Don't trim if the paragraph itself contains markdown structure.
+        if any(
+            ln.lstrip().startswith(("#", "- ", "* ", "+ ", "> ", "| ", "```"))
+            for ln in lines[para_start:]
+        ):
+            break
+        lowered = paragraph.lower()
+        if not any(sig in lowered for sig in _META_COMMENTARY_SIGNALS):
+            break
+        del lines[para_start:]
+        trimmed_any = True
+    result = "\n".join(lines)
+    if trimmed_any and content.endswith("\n"):
+        result += "\n"
+    return result
 
 
 def _format_graph_context_for_prompt(graph_context: dict) -> str:
@@ -413,6 +704,14 @@ content starting with ``# init.md``. Do NOT produce narrative text like
 blocks — narration without an actual function call is treated as a
 finished answer by the runtime and the document never gets written.
 
+How persistence works: your final assistant message IS the saved
+``.victor/init.md`` file. The runtime captures that message verbatim
+and writes it to disk for you. Write/edit/shell tools are
+intentionally disabled for this task. Do NOT attempt to call them, and
+do NOT add a postamble explaining what tools were or weren't available
+— any prose appended after the last markdown section gets written into
+the file as visible junk.
+
 Rules:
 1. The "Measured Project Scale" section below is ground truth. Quote
    those numbers verbatim. If your draft references a count not listed
@@ -421,7 +720,11 @@ Rules:
    only.
 3. Target 100-180 lines. Use Markdown tables for structured data.
 4. Return ONLY the init.md markdown content (start with ``# init.md``),
-   no preamble, no postamble, no commentary.
+   no preamble, no postamble, no commentary. Do NOT wrap the document
+   in a ``` ```markdown ... ``` ``` fence. Do NOT add a closing note
+   about tool availability, file-saving, or what you would have done
+   differently — the last line of your response must be the last line
+   of the document.
 
 ---
 
@@ -594,9 +897,7 @@ class InitSynthesizer:
         if agent:
             return await self._run_with_orchestrator(agent, prompt)
         else:
-            return await self._run_with_fresh_agent(
-                prompt, resolved_provider, resolved_model
-            )
+            return await self._run_with_fresh_agent(prompt, resolved_provider, resolved_model)
 
     async def synthesize_with_tools(
         self,
@@ -717,18 +1018,62 @@ class InitSynthesizer:
                 _trimmed = _trim_to_first_markdown_heading(content)
                 if _trimmed is not None:
                     content = _trimmed
-                return self._clean(content)
+                # Strip a chat-style leading recap that has no markdown
+                # heading at all (so the previous step couldn't help).
+                # Observed when the agentic loop runs extra iterations
+                # after the deliverable was already produced — the model
+                # responds "the init.md was already generated... " in
+                # the final turn and that recap gets persisted.
+                _pre_trim = _strip_leading_meta_commentary(content)
+                if _pre_trim != content:
+                    logger.info(
+                        "[init] trimmed leading meta-commentary from "
+                        "agentic synthesis output (%d -> %d chars)",
+                        len(content),
+                        len(_pre_trim),
+                    )
+                    content = _pre_trim
+                # Strip any trailing self-reflective paragraph the model
+                # may have appended about tool availability / inability
+                # to save the file. Observed leak: agent emitted full
+                # init.md then a "No write/edit tool available …" coda
+                # that got persisted verbatim into the saved doc.
+                _post_trim = _strip_trailing_meta_commentary(content)
+                if _post_trim != content:
+                    logger.info(
+                        "[init] trimmed trailing meta-commentary from "
+                        "agentic synthesis output (%d -> %d chars)",
+                        len(content),
+                        len(_post_trim),
+                    )
+                    content = _post_trim
+                cleaned = self._clean(content)
+                # Sanity check: if the cleaned output has no markdown
+                # headings, the model didn't produce a real document
+                # (typically a recap-only final turn). Returning the
+                # recap would persist chat junk into ``.victor/init.md``
+                # (and worse, init.py then appends synthetic sections
+                # like "## Architecture Patterns" AFTER the junk, making
+                # it look almost-real). Treat as failed synthesis so the
+                # caller falls back to base content.
+                if cleaned and not self._has_document_structure(cleaned):
+                    logger.warning(
+                        "[init] agentic synthesis produced no markdown "
+                        "structure (chars=%d, lines=%d); treating as "
+                        "failed synthesis. First 200 chars: %r",
+                        len(cleaned),
+                        cleaned.count("\n") + 1,
+                        cleaned[:200],
+                    )
+                    return ""
+                return cleaned
             except Exception as e:
                 logger.warning("Init synthesis with tools failed: %s", e)
                 return ""
         else:
-            return await self._run_agent_with_tools(
-                prompt, provider, model, vertical="coding"
-            )
+            return await self._run_agent_with_tools(prompt, provider, model, vertical="coding")
 
-    async def _run_with_orchestrator(
-        self, agent: "AgentOrchestrator", prompt: str
-    ) -> str:
+    async def _run_with_orchestrator(self, agent: "AgentOrchestrator", prompt: str) -> str:
         """Run synthesis using an existing orchestrator or framework Agent.
 
         Handles two agent types:
@@ -776,9 +1121,7 @@ class InitSynthesizer:
             # 3. Last resort: fall back to agent.chat() for slash command contexts where
             #    the orchestrator's provider attribute may not be directly accessible.
             if inspect.iscoroutinefunction(getattr(agent, "chat", None)):
-                logger.debug(
-                    "[init] No direct provider found, falling back to agent.chat()"
-                )
+                logger.debug("[init] No direct provider found, falling back to agent.chat()")
                 response = await agent.chat(prompt)
                 content = response.content if response else ""
                 return self._clean(content)
@@ -865,9 +1208,7 @@ class InitSynthesizer:
 
         settings = load_settings()
         provider_settings = getattr(settings, "provider", None)
-        profiles = (
-            settings.load_profiles() if hasattr(settings, "load_profiles") else {}
-        )
+        profiles = settings.load_profiles() if hasattr(settings, "load_profiles") else {}
 
         resolved_provider: Optional[str] = None
         resolved_model = model
@@ -882,9 +1223,7 @@ class InitSynthesizer:
                 resolved_model = getattr(requested_profile, "model", None)
 
         if resolved_provider is None:
-            default_profile = (
-                profiles.get("default") if isinstance(profiles, dict) else None
-            )
+            default_profile = profiles.get("default") if isinstance(profiles, dict) else None
             profile_provider = getattr(default_profile, "provider", None)
             profile_model = getattr(default_profile, "model", None)
             resolved_provider = (
@@ -909,9 +1248,7 @@ class InitSynthesizer:
         provider_key_lower = provider_key.lower()
         requested_key = str(requested_provider or provider_key).lower()
 
-        canonical_provider = (
-            "zai" if provider_key_lower in _ZAI_PROVIDER_ALIASES else provider_key
-        )
+        canonical_provider = "zai" if provider_key_lower in _ZAI_PROVIDER_ALIASES else provider_key
         provider_init_model = resolved_model
         if canonical_provider == "zai":
             if (
@@ -941,18 +1278,16 @@ class InitSynthesizer:
         ``Settings.get_provider_settings(...)`` instead of reconstructing just
         provider/model manually.
         """
-        effective_provider = (
-            getattr(profile, "provider", None) or requested_profile_name
-        )
+        effective_provider = getattr(profile, "provider", None) or requested_profile_name
         request_model = model_override or getattr(profile, "model", None)
         temperature = float(getattr(profile, "temperature", 0.7) or 0.7)
         max_tokens = int(getattr(profile, "max_tokens", 4096) or 4096)
         profile_extras = dict(getattr(profile, "__pydantic_extra__", {}) or {})
 
-        provider_kwargs = dict(
-            settings.get_provider_settings(effective_provider, profile_extras)
+        provider_kwargs = dict(settings.get_provider_settings(effective_provider, profile_extras))
+        provider_kwargs["timeout"] = _init_provider_timeout(
+            str(effective_provider), provider_kwargs.get("timeout")
         )
-        provider_kwargs.setdefault("timeout", INIT_PROVIDER_TIMEOUT_SECONDS)
         provider_kwargs["max_retries"] = INIT_PROVIDER_MAX_RETRIES
 
         return InitProviderBootstrap(
@@ -978,9 +1313,7 @@ class InitSynthesizer:
         from victor.config.settings import load_settings
 
         settings = load_settings()
-        profiles = (
-            settings.load_profiles() if hasattr(settings, "load_profiles") else {}
-        )
+        profiles = settings.load_profiles() if hasattr(settings, "load_profiles") else {}
 
         requested_profile = None
         requested_profile_name: Optional[str] = None
@@ -989,9 +1322,7 @@ class InitSynthesizer:
             requested_profile_name = provider if requested_profile is not None else None
         elif provider is None and isinstance(profiles, dict):
             requested_profile = profiles.get("default")
-            requested_profile_name = (
-                "default" if requested_profile is not None else None
-            )
+            requested_profile_name = "default" if requested_profile is not None else None
 
         if requested_profile is not None and requested_profile_name is not None:
             return InitSynthesizer._build_profile_bootstrap(
@@ -1011,17 +1342,16 @@ class InitSynthesizer:
         profile_overrides: dict[str, Any] = {}
         if canonical_provider == "zai" and (
             requested_key in _ZAI_CODING_PROVIDER_ALIASES
-            or (
-                provider_init_model is not None
-                and provider_init_model.endswith(":coding")
-            )
+            or (provider_init_model is not None and provider_init_model.endswith(":coding"))
         ):
             profile_overrides["coding_plan"] = True
 
         provider_kwargs = dict(
             settings.get_provider_settings(canonical_provider, profile_overrides)
         )
-        provider_kwargs.setdefault("timeout", INIT_PROVIDER_TIMEOUT_SECONDS)
+        provider_kwargs["timeout"] = _init_provider_timeout(
+            str(canonical_provider), provider_kwargs.get("timeout")
+        )
         provider_kwargs["max_retries"] = INIT_PROVIDER_MAX_RETRIES
         if provider_init_model is not None and (
             provider_init_model != resolved_model or ":" in provider_init_model
@@ -1042,11 +1372,9 @@ class InitSynthesizer:
         model: Optional[str],
     ) -> tuple[str, Optional[str]]:
         """Resolve canonical provider/model using profile-aware init routing rules."""
-        resolved_provider, resolved_model, _ = (
-            InitSynthesizer._resolve_provider_request(
-                provider,
-                model,
-            )
+        resolved_provider, resolved_model, _ = InitSynthesizer._resolve_provider_request(
+            provider,
+            model,
         )
         return resolved_provider, resolved_model
 
@@ -1064,13 +1392,9 @@ class InitSynthesizer:
 
         settings = load_settings()
         provider_settings = getattr(settings, "provider", None)
-        profiles = (
-            settings.load_profiles() if hasattr(settings, "load_profiles") else {}
-        )
+        profiles = settings.load_profiles() if hasattr(settings, "load_profiles") else {}
 
-        default_profile = (
-            profiles.get("default") if isinstance(profiles, dict) else None
-        )
+        default_profile = profiles.get("default") if isinstance(profiles, dict) else None
         if getattr(default_profile, "provider", None) == "ollama":
             return "ollama", getattr(default_profile, "model", None)
 
@@ -1102,23 +1426,40 @@ class InitSynthesizer:
         failed_model: Optional[str],
         error: Exception,
     ) -> Optional[str]:
-        """Retry init synthesis with local Ollama once after remote rate limiting."""
-        from victor.core.errors import ProviderRateLimitError
+        """Retry init synthesis with a local model once after a recoverable remote failure.
 
-        if not isinstance(error, ProviderRateLimitError):
+        Triggers on rate limiting, timeouts, and connection errors — a slow or
+        throttled *cloud* provider can fall back to local Ollama. A local provider
+        that itself times out resolves to no fallback (the excluded provider is
+        the only local one), so the caller degrades to the template instead.
+        """
+        from victor.core.errors import ProviderError, ProviderRateLimitError
+
+        try:
+            from victor.core.errors import ProviderTimeoutError
+        except Exception:  # pragma: no cover - defensive import
+            ProviderTimeoutError = ()  # type: ignore[assignment, misc]
+
+        recoverable = isinstance(error, (ProviderRateLimitError, ProviderTimeoutError))
+        # Bare connection/timeout errors surface as ProviderError or OSError.
+        if not recoverable and isinstance(error, (ProviderError, OSError, TimeoutError)):
+            message = str(error).lower()
+            recoverable = any(
+                token in message for token in ("timed out", "timeout", "connection", "unavailable")
+            )
+        if not recoverable:
             return None
 
-        fallback = self._resolve_local_fallback_selection(
-            exclude_provider=failed_provider
-        )
+        fallback = self._resolve_local_fallback_selection(exclude_provider=failed_provider)
         if fallback is None:
             return None
 
         fallback_provider, fallback_model = fallback
         logger.warning(
-            "[init] Provider %s/%s exhausted; retrying synthesis with local fallback %s/%s",
+            "[init] Provider %s/%s failed (%s); retrying synthesis with local fallback %s/%s",
             failed_provider,
             failed_model,
+            type(error).__name__,
             fallback_provider,
             fallback_model,
         )
@@ -1149,9 +1490,7 @@ class InitSynthesizer:
 
         from victor.providers.base import Message
 
-        provider_name = getattr(
-            provider_instance, "name", type(provider_instance).__name__
-        )
+        provider_name = getattr(provider_instance, "name", type(provider_instance).__name__)
         resolved_provider = provider_name
         resolved_model = model
         if provider_name == "ollama":
@@ -1237,9 +1576,7 @@ class InitSynthesizer:
                 **bootstrap.provider_init_kwargs,
             )
             if not provider_instance:
-                raise RuntimeError(
-                    f"Could not create provider {bootstrap.provider_name}"
-                )
+                raise RuntimeError(f"Could not create provider {bootstrap.provider_name}")
 
             model = await self._preflight_provider(
                 bootstrap.provider_name,
@@ -1269,9 +1606,7 @@ class InitSynthesizer:
             if model is not None:
                 chat_kwargs["model"] = model
             try:
-                response = await provider_instance.chat(
-                    messages=messages, **chat_kwargs
-                )
+                response = await provider_instance.chat(messages=messages, **chat_kwargs)
             except Exception as exc:
                 if allow_local_fallback:
                     fallback_result = await self._maybe_retry_with_local_fallback(
@@ -1355,7 +1690,11 @@ class InitSynthesizer:
 
             return result
         except Exception as e:
-            logger.warning("Init synthesis via provider failed: %s", e)
+            logger.warning(
+                "Init synthesis via provider failed [%s]: %s — falling back to template",
+                _classify_init_failure(e),
+                e,
+            )
             raise
         finally:
             if provider_instance is not None:
@@ -1390,15 +1729,73 @@ class InitSynthesizer:
             return ""
 
     @staticmethod
+    def _has_document_structure(content: str) -> bool:
+        """True if content contains at least one markdown heading.
+
+        Used as a sanity check after cleanup — synthesis output that
+        survived the trim helpers but has no headings at all is almost
+        certainly a chat-style recap, not a real init.md document.
+        """
+        for line in content.splitlines():
+            stripped = line.lstrip()
+            if stripped.startswith("#"):
+                # Require ``# `` / ``## `` etc. — at least one space
+                # after the leading hashes to count as a heading.
+                hashes = 0
+                while hashes < len(stripped) and stripped[hashes] == "#":
+                    hashes += 1
+                if hashes < len(stripped) and stripped[hashes] in (" ", "\t"):
+                    return True
+        return False
+
+    @staticmethod
     def _clean(content: str) -> str:
-        """Clean LLM output — strip code fences, validate markdown."""
+        """Clean LLM output — strip code fences and meta-commentary.
+
+        Four things get trimmed here, in order:
+
+        1. A wrapping ``` ```markdown … ``` ``` fence (model occasionally
+           wraps the whole doc in a single fenced block).
+        2. A leading chat-style recap before the first heading (see
+           ``_strip_leading_meta_commentary``).
+        3. A trailing self-reflective paragraph about tool availability
+           or inability to save the file (see
+           ``_strip_trailing_meta_commentary``).
+        4. An orphan trailing ``` ``` ``` line on its own — happens when
+           the preamble trim earlier in the pipeline ate the opening
+           fence but the closing fence survived because the model
+           appended postamble text after it.
+        """
         content = content.strip()
         if content.startswith("```"):
             lines = content.split("\n")
             lines = lines[1:] if lines[0].startswith("```") else lines
             lines = lines[:-1] if lines and lines[-1].strip() == "```" else lines
-            content = "\n".join(lines)
-        return content
+            content = "\n".join(lines).strip()
+        # Leading meta-commentary trim catches recap-only outputs that
+        # the earlier first-heading trim couldn't (because the recap
+        # contains no headings to anchor on). Runs before the trailing
+        # trim so signal-phrase detection doesn't accidentally fire on
+        # body text below.
+        content = _strip_leading_meta_commentary(content)
+        # Order matters: trim meta-commentary BEFORE stripping orphan
+        # trailing fences, because the meta paragraph often sits AFTER
+        # the orphan fence. Stripping the fence first wouldn't help
+        # since the paragraph below it survives, and stripping meta
+        # first exposes the orphan fence so the next step can drop it.
+        content = _strip_trailing_meta_commentary(content)
+        # Even if the opening fence was already trimmed (e.g. by the
+        # preamble-trim path that jumps to the first ``# `` heading),
+        # the closing fence may still be sitting on a line by itself
+        # in the tail. Drop trailing blanks + fences, alternating, so
+        # we handle ``...\n```\n\n``` patterns too.
+        lines = content.splitlines()
+        while lines and (
+            not lines[-1].strip() or lines[-1].strip() in ("```", "```markdown", "```md")
+        ):
+            lines.pop()
+        content = "\n".join(lines)
+        return content.strip()
 
     async def _pre_synthesis_discovery(
         self, agent: Optional["AgentOrchestrator"] = None
@@ -1429,9 +1826,7 @@ class InitSynthesizer:
                 if coupling_result["success"] and coupling_result["result"]["results"]:
                     discovery_lines.append("### Highly Coupled Modules (Fan-in)")
                     for row in coupling_result["result"]["results"]:
-                        discovery_lines.append(
-                            f"- {row['dst']} ({row['count']} importers)"
-                        )
+                        discovery_lines.append(f"- {row['dst']} ({row['count']} importers)")
                     discovery_lines.append("")
             except Exception:
                 pass
@@ -1451,9 +1846,7 @@ class InitSynthesizer:
                 if size_result["success"] and size_result["result"]["results"]:
                     discovery_lines.append("### Module Implementation Depth")
                     for row in size_result["result"]["results"]:
-                        discovery_lines.append(
-                            f"- {row['file']} ({row['count']} symbols)"
-                        )
+                        discovery_lines.append(f"- {row['file']} ({row['count']} symbols)")
                     discovery_lines.append("")
             except Exception:
                 pass
@@ -1471,9 +1864,7 @@ class InitSynthesizer:
                         semantic_result["success"]
                         and semantic_result["result"]["potential_relationships"]
                     ):
-                        discovery_lines.append(
-                            f"### Semantic Relationships for '{top_hub}'"
-                        )
+                        discovery_lines.append(f"### Semantic Relationships for '{top_hub}'")
                         for rel in semantic_result["result"]["potential_relationships"]:
                             discovery_lines.append(
                                 f"- {rel['name']} ({rel['file']}) - score: {rel['similarity']}"
@@ -1521,9 +1912,7 @@ class InitSynthesizer:
             length_score = 0.3
 
         # Combined quality score
-        quality_score = (
-            section_score * 0.6 + length_score * 0.2 + (0.2 if result else 0.0)
-        )
+        quality_score = section_score * 0.6 + length_score * 0.2 + (0.2 if result else 0.0)
 
         usage.log_event(
             "init_quality",
@@ -1598,9 +1987,7 @@ class InitSynthesizer:
                     if len(text) > 1500:
                         trimmed += "\n... (truncated)"
                     enrichments.append(f"## README (first 1500 chars)\n\n{trimmed}")
-                    logger.info(
-                        "[init] Enriched with %s (%d chars)", name, len(trimmed)
-                    )
+                    logger.info("[init] Enriched with %s (%d chars)", name, len(trimmed))
                     break
                 except Exception:
                     pass
@@ -1649,12 +2036,8 @@ class InitSynthesizer:
                     trimmed = text[:1500]
                     if len(text) > 1500:
                         trimmed += "\n... (truncated)"
-                    enrichments.append(
-                        f"## Build Manifest ({name})\n\n```\n{trimmed}\n```"
-                    )
-                    logger.info(
-                        "[init] Enriched with %s (%d chars)", name, len(trimmed)
-                    )
+                    enrichments.append(f"## Build Manifest ({name})\n\n```\n{trimmed}\n```")
+                    logger.info("[init] Enriched with %s (%d chars)", name, len(trimmed))
                     break
                 except Exception:
                     pass
@@ -1672,9 +2055,7 @@ class InitSynthesizer:
                 try:
                     snippet = reader(path)
                     if snippet:
-                        enrichments.append(
-                            f"## Task Runner ({name})\n\n```\n{snippet}\n```"
-                        )
+                        enrichments.append(f"## Task Runner ({name})\n\n```\n{snippet}\n```")
                         logger.info("[init] Enriched with %s", name)
                     break
                 except Exception:
@@ -1750,8 +2131,7 @@ class InitSynthesizer:
             )
             if rec and rec.confidence > 0.6 and not rec.is_baseline:
                 logger.info(
-                    "Using GEPA-evolved init rules "
-                    "(gen=%s, confidence=%.2f, %d chars)",
+                    "Using GEPA-evolved init rules " "(gen=%s, confidence=%.2f, %d chars)",
                     rec.reason,
                     rec.confidence,
                     len(rec.value),

--- a/victor/tools/code_search_tool.py
+++ b/victor/tools/code_search_tool.py
@@ -9,7 +9,7 @@ import warnings
 import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set, Tuple
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Set, Tuple
 
 from victor.core.indexing.graph_enrichment import ensure_project_graph_enriched
 from victor.framework.enrichment.file_patterns import CODE_PATTERNS
@@ -586,6 +586,55 @@ async def _background_index_rebuild(index: Any, rebuild_timeout: float = 120.0) 
         return False
 
 
+def _filename_search_timeout() -> float:
+    """Timeout (seconds) for the filename ``find`` subprocess (env-overridable).
+
+    Walking a large source tree with ``find`` is O(files); the previous hardcoded
+    15s fired on big repos. Override via ``VICTOR_TIMEOUT_FILENAME_SEARCH``.
+    """
+    return float(
+        os.environ.get(
+            "VICTOR_TIMEOUT_FILENAME_SEARCH",
+            os.environ.get("VICTOR_FILENAME_SEARCH_TIMEOUT", "45.0"),
+        )
+    )
+
+
+# Single-flight registry for background index rebuilds, keyed by project root.
+# Without this, every stale code_search call spawns a fresh fire-and-forget
+# rebuild; concurrent rebuilds on a large repo thrash the same embeddings store
+# and cascade into repeated probe timeouts.
+_INFLIGHT_INDEX_REBUILDS: Dict[str, "asyncio.Task[Any]"] = {}
+
+
+def _spawn_index_rebuild_once(
+    root_key: str, coro_factory: Callable[[], Any]
+) -> "asyncio.Task[Any]":
+    """Spawn a background rebuild for ``root_key`` unless one is already running.
+
+    Returns the in-flight task (existing or newly created). ``coro_factory`` is
+    only invoked when a new task is actually spawned, so no orphan coroutine is
+    created when a rebuild is deduplicated.
+    """
+    existing = _INFLIGHT_INDEX_REBUILDS.get(root_key)
+    if existing is not None and not existing.done():
+        logger.info(
+            "[code_search] Index rebuild already in-flight for %s; skipping duplicate",
+            root_key,
+        )
+        return existing
+
+    task = asyncio.create_task(coro_factory())
+    _INFLIGHT_INDEX_REBUILDS[root_key] = task
+
+    def _clear(done_task: "asyncio.Task[Any]", key: str = root_key) -> None:
+        if _INFLIGHT_INDEX_REBUILDS.get(key) is done_task:
+            _INFLIGHT_INDEX_REBUILDS.pop(key, None)
+
+    task.add_done_callback(_clear)
+    return task
+
+
 def _get_index_cache(exec_ctx: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
     """Get the index cache, preferring DI-injected cache if available.
 
@@ -777,12 +826,16 @@ def _extract_exception_cause(exc: Exception) -> str:
 def _calculate_index_build_timeout(root_path: Path) -> float:
     """Calculate dynamic timeout for index building based on codebase size.
 
-    Uses a heuristic based on the number of Python files and total directory size
-    to estimate embedding time. Formula:
+    Counts indexable source files across all supported languages (not just
+    Python) as a proxy for embedding time. Formula:
     - Base timeout: 60 seconds
-    - +5 seconds per Python file (max 300s for files)
+    - +5 seconds per source file (max 300s for files)
     - +1 second per 1000 estimated symbols (max 300s for symbols)
     - Cap at 600 seconds (10 minutes) for very large codebases
+
+    Counting only ``.py`` files (the previous behavior) gave large Rust/Go/TS
+    repositories the 60s base timeout, which always fired before the index
+    finished and triggered repeated background rebuilds.
 
     Args:
         root_path: Path to the codebase root
@@ -801,48 +854,31 @@ def _calculate_index_build_timeout(root_path: Path) -> float:
     )
 
     try:
-        # Count Python files as a proxy for codebase size
-        py_file_count = 0
+        # Count indexable source files (all supported languages) as a size proxy.
+        source_file_count = 0
         total_size_bytes = 0
+        source_extensions = tuple(DEFAULT_CODE_EXTENSIONS)
+        # ``.victor`` can hold large caches (e.g. swe_bench_cache); ``env`` is a
+        # common virtualenv dir. Exclude both alongside the shared EXCLUDE_DIRS.
+        excluded_dirs = set(EXCLUDE_DIRS) | {".victor", "env"}
 
         for root, dirs, files in os.walk(root_path):
             # Skip excluded directories
-            dirs[:] = [
-                d
-                for d in dirs
-                if d
-                not in {
-                    ".git",
-                    "__pycache__",
-                    ".venv",
-                    "venv",
-                    "env",
-                    "node_modules",
-                    ".victor",
-                    "build",
-                    "dist",
-                    ".eggs",
-                    "*.egg-info",
-                    ".tox",
-                    ".mypy_cache",
-                    ".pytest_cache",
-                }
-            ]
+            dirs[:] = [d for d in dirs if d not in excluded_dirs]
 
             for file in files:
-                if file.endswith(".py"):
-                    py_file_count += 1
+                if file.endswith(source_extensions):
+                    source_file_count += 1
                     try:
                         total_size_bytes += os.path.getsize(os.path.join(root, file))
                     except (OSError, IOError):
                         pass
 
-        # Estimate symbols: roughly 100 symbols per 1000 lines of code
-        # Average 50 lines per file = 20 symbols per file
-        estimated_symbols = py_file_count * 20
+        # Estimate symbols: roughly 20 symbols per file on average.
+        estimated_symbols = source_file_count * 20
 
         # Calculate timeout
-        file_timeout = min(py_file_count * 5.0, 300.0)  # Max 5 minutes from files
+        file_timeout = min(source_file_count * 5.0, 300.0)  # Max 5 minutes from files
         symbol_timeout = min(estimated_symbols / 1000.0 * 10.0, 300.0)  # Max 5 minutes from symbols
         size_timeout = min(total_size_bytes / (1024 * 1024) * 30.0, 200.0)  # Max 200s from size
 
@@ -852,7 +888,7 @@ def _calculate_index_build_timeout(root_path: Path) -> float:
         logger.debug(
             "[code_search] Timeout calculation for %s: %d files, %d MB, ~%d symbols → %.1fs timeout",
             root_path,
-            py_file_count,
+            source_file_count,
             total_size_bytes // (1024 * 1024),
             estimated_symbols,
             final_timeout,
@@ -2456,8 +2492,9 @@ async def _get_or_build_index(
                                 exc,
                             )
 
-                # Spawn background task
-                asyncio.create_task(_rebuildInBackground())
+                # Spawn background task (single-flight per root to avoid concurrent
+                # rebuilds thrashing the same embeddings store).
+                _spawn_index_rebuild_once(str(root), _rebuildInBackground)
 
                 # Cache stale index for immediate use
                 index_cache[str(root)] = {
@@ -2674,7 +2711,10 @@ async def _literal_search(
                     stdout=asyncio.subprocess.PIPE,
                     stderr=asyncio.subprocess.PIPE,
                 )
-                stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=15)
+                filename_timeout = _filename_search_timeout()
+                stdout, stderr = await asyncio.wait_for(
+                    proc.communicate(), timeout=filename_timeout
+                )
                 find_result = type(
                     "obj",
                     (object,),
@@ -2719,11 +2759,14 @@ async def _literal_search(
                         "mode": "filename",
                     }
             except asyncio.TimeoutError:
-                logger.debug("Filename search timed out after 15s")
+                logger.debug("Filename search timed out after %.0fs", filename_timeout)
                 if filename_only:
                     return {
                         "success": False,
-                        "error": "Filename search timed out after 15s",
+                        "error": (
+                            f"Filename search timed out after {filename_timeout:.0f}s "
+                            "(raise VICTOR_TIMEOUT_FILENAME_SEARCH for very large trees)"
+                        ),
                         "results": [],
                         "count": 0,
                         "mode": "filename",

--- a/victor/tools/graph_tool.py
+++ b/victor/tools/graph_tool.py
@@ -471,6 +471,30 @@ def _normalize_relpath(file_path: str) -> str:
     return file_path.replace("\\", "/").strip()
 
 
+# Directory-module index filenames whose parent dir names the module
+# (e.g. ``src/network/mod.rs`` -> module ``src/network``).
+_MODULE_INDEX_STEMS = ("/mod", "/__init__", "/index")
+
+
+def _module_path_stem(file_path: str) -> str:
+    """Return a file path with its extension and directory-module suffix removed.
+
+    Used to match Python/dotted-style module references (``src.network``) against
+    real file nodes regardless of language extension:
+      ``src/network/multi_server.rs`` -> ``src/network/multi_server``
+      ``src/network/mod.rs``          -> ``src/network``
+      ``src/lib.rs``                  -> ``src/lib``
+    """
+    normalized = _normalize_relpath(file_path)
+    suffix = Path(normalized).suffix
+    if suffix:
+        normalized = normalized[: -len(suffix)]
+    for tail in _MODULE_INDEX_STEMS:
+        if normalized.endswith(tail):
+            return normalized[: -len(tail)]
+    return normalized
+
+
 def _project_graph_watch_daemon_active(root_path: Path) -> bool:
     """Return True when a project-scoped graph-watch daemon is alive."""
     pid_file = get_project_paths(root_path).project_victor_dir / "graph-watch.pid"
@@ -766,16 +790,22 @@ def _build_graph_error_follow_up_suggestions(
         )
 
     if search_seed:
+        # Dotted module references (``src.network.multi_server``) rarely match
+        # path-based file nodes; seed the search with a path-style variant so the
+        # follow-up actually resolves on non-Python repos.
+        search_query = search_seed
+        if "." in search_seed and "/" not in search_seed and ":" not in search_seed:
+            search_query = search_seed.replace(".", "/")
         suggestions.append(
             _build_follow_up_suggestion(
                 "graph",
                 {
                     "mode": "search",
-                    "query": search_seed,
+                    "query": search_query,
                     "path": path,
                     "top_k": effective_top_k,
                 },
-                f'Search the graph index for matches to "{search_seed}".',
+                f'Search the graph index for matches to "{search_query}".',
             )
         )
     elif not suggestions:
@@ -971,6 +1001,9 @@ class GraphAnalyzer:
                     candidates.append(node.node_id)
 
         if not candidates:
+            candidates.extend(self._resolve_dotted_reference(normalized, lowered=lowered))
+
+        if not candidates:
             return None
 
         def _score(node_id: str) -> tuple[int, int, str]:
@@ -1020,6 +1053,35 @@ class GraphAnalyzer:
         else:
             matches.sort()
         return matches
+
+    def _resolve_dotted_reference(self, normalized: str, *, lowered: str) -> List[str]:
+        """Resolve Python/dotted module references against path-based file nodes.
+
+        Models frequently address files with dotted module syntax
+        (``src.network.multi_server``) even in non-Python repos where the graph
+        stores path-based file nodes (``src/network/multi_server.rs``). Convert
+        the dotted reference to a slashed stem and match file nodes
+        language-agnostically; fall back to the last segment as a symbol name.
+        """
+        if "." not in normalized or "/" in normalized or ":" in normalized:
+            return []
+
+        slashed = _normalize_relpath(normalized.replace(".", "/"))
+        if not slashed:
+            return []
+
+        candidates: List[str] = []
+        for file_path, node_ids in self._file_index.items():
+            stem = _module_path_stem(file_path)
+            if stem == slashed or stem.endswith("/" + slashed):
+                candidates.extend(node_ids)
+
+        if not candidates:
+            last_segment = normalized.rsplit(".", 1)[-1].strip().lower()
+            if last_segment and last_segment != lowered:
+                candidates.extend(self._name_index.get(last_segment, ()))
+
+        return candidates
 
     def search(
         self,
@@ -2094,21 +2156,32 @@ def _build_degree_centrality_from_project_store(
     # Build separate filters for node and edge clauses
     node_where_clauses = []
     edge_where_clauses = []
-    params = []
+    edge_params: List[str] = []
+    node_params: List[str] = []
 
     if node_types:
         placeholders = ",".join("?" for _ in node_types)
         node_where_clauses.append(f"n.type IN ({placeholders})")
-        params.extend(node_types)
+        node_params.extend(node_types)
+
+    scope = _project_relative_scope(root_path)
+    if scope:
+        node_where_clauses.append("n.file LIKE ?")
+        node_params.append(f"{scope}/%")
 
     if edge_types:
         placeholders = ",".join("?" for _ in edge_types)
         edge_where_clauses.append(f"e.type IN ({placeholders})")
-        params.extend(edge_types)
+        edge_params.extend(edge_types)
 
     # Build WHERE clauses for different contexts
     edge_where_sql = f"WHERE {' AND '.join(edge_where_clauses)}" if edge_where_clauses else ""
     node_where_sql = f"WHERE {' AND '.join(node_where_clauses)}" if node_where_clauses else ""
+
+    # Bind parameters in the exact order placeholders appear in the query below:
+    # the edge filter is interpolated twice (outgoing + incoming subqueries), so
+    # its params must be supplied twice, then the outer node filter, then LIMIT.
+    params: List[Any] = [*edge_params, *edge_params, *node_params]
 
     # Compute degree centrality using SQL aggregation
     # Count both outgoing (src) and incoming (dst) edges
@@ -2176,6 +2249,28 @@ def _build_degree_centrality_from_project_store(
     }
 
 
+def _project_relative_scope(root_path: Path) -> Optional[str]:
+    """Return the POSIX subpath of ``root_path`` within its project, or None.
+
+    Broad graph modes query the single project-level database (whole repo). When
+    the caller scopes a request to a subdirectory (e.g. ``src/network``), this
+    returns ``"src/network"`` so the SQL can be filtered to that subtree via a
+    ``n.file LIKE scope || '/%'`` predicate. Returns ``None`` when the request is
+    at (or above) the project root, i.e. genuinely repo-wide.
+    """
+    from victor.core.database import resolve_project_db_root
+
+    project_root = resolve_project_db_root(root_path)
+    try:
+        rel = Path(root_path).resolve().relative_to(project_root)
+    except ValueError:
+        return None
+    rel_str = rel.as_posix()
+    if rel_str in ("", "."):
+        return None
+    return rel_str
+
+
 def _build_cheap_overview_from_project_store(
     root_path: Path,
     *,
@@ -2185,6 +2280,8 @@ def _build_cheap_overview_from_project_store(
 
     This avoids materializing very large graphs and never triggers semantic
     index rebuilds. It is intentionally degree-based rather than full PageRank.
+    When ``root_path`` is a subdirectory of the project, results are scoped to
+    that subtree via ``n.file`` prefix matching.
     """
     from victor.core.database import get_project_database
 
@@ -2192,31 +2289,42 @@ def _build_cheap_overview_from_project_store(
     _ensure_project_graph_tables(project_db)
 
     limit = max(1, min(int(top_k or 10), 25))
+    scope = _project_relative_scope(root_path)
+    scope_like = f"{scope}/%" if scope else None
+    scope_sql = " AND n.file LIKE ?" if scope_like else ""
     symbol_types = tuple(sorted(_SYMBOL_TYPES))
     placeholders = ",".join("?" for _ in symbol_types)
+    symbol_params: List[Any] = [*symbol_types]
+    if scope_like:
+        symbol_params.append(scope_like)
+    symbol_params.append(limit)
     symbol_rows = project_db.query(
         f"""
         SELECT n.node_id, n.name, n.type, n.file, COUNT(e.src) AS degree
         FROM graph_node n
         LEFT JOIN graph_edge e ON e.src = n.node_id OR e.dst = n.node_id
-        WHERE n.type IN ({placeholders})
+        WHERE n.type IN ({placeholders}){scope_sql}
         GROUP BY n.node_id, n.name, n.type, n.file
         ORDER BY degree DESC, n.file ASC, n.name ASC
         LIMIT ?
         """,
-        (*symbol_types, limit),
+        tuple(symbol_params),
     )
+    module_params: List[Any] = []
+    if scope_like:
+        module_params.append(scope_like)
+    module_params.append(limit)
     module_rows = project_db.query(
-        """
+        f"""
         SELECT n.file AS module_path, COUNT(e.src) AS degree
         FROM graph_node n
         LEFT JOIN graph_edge e ON e.src = n.node_id OR e.dst = n.node_id
-        WHERE n.file IS NOT NULL AND n.file != ''
+        WHERE n.file IS NOT NULL AND n.file != ''{scope_sql}
         GROUP BY n.file
         ORDER BY degree DESC, n.file ASC
         LIMIT ?
         """,
-        (limit,),
+        tuple(module_params),
     )
     modules = [
         {


### PR DESCRIPTION
## Context

Running `victor chat` against **ProximaDB** (a ~3,000-file, 941K-graph-node Rust codebase) to generate architecture diagrams surfaced a cascade of tool failures (console transcript + `~/.victor/logs/victor.log`). They share one root cause: **the code-intelligence tooling assumed a small, Python, project-root-cwd repo.** On a large polyglot repo queried by subpath, every assumption broke. This PR fixes the correctness bugs, hardens resilience/UX, and consolidates the root-cause class.

## Symptom → fix

| Symptom (from logs) | Fix |
|---|---|
| `graph(mode=overview, path=src/network)` → *"Project graph database is unavailable for broad graph analytics"* (16×); `reindex=True` worked around it | `_normalize_project_database_paths` now walks up to the repo's real `.victor/project.db` instead of fabricating an empty one under the subdir (and littering stray `.victor/` dirs). Auto-fixes the gate for all fast-path builders. |
| `graph(mode=patterns, edge_group=type_hierarchy)` → *"Incorrect number of bindings: 15 vs 12"* | Centrality SQL binds the edge-type filter twice (one per degree subquery) in placeholder order. |
| `graph(mode=neighbors, node='src.lib')` → *"Could not resolve graph node"* (8×) | Resolver maps dotted refs to path candidates (`src/lib.rs`, `mod.rs`); recovery hint seeded with the path-style form. |
| `graph(mode=overview, path=src)` returned whole-repo data | Cheap overview/centrality builders scope to the requested subtree via `n.file` prefix. |
| `code_search(mode=filename)` → *"timed out after 15s"* | Env-overridable `VICTOR_TIMEOUT_FILENAME_SEARCH` (default 45s). |
| *"Semantic index build timed out after 60.0s"* + *"probe timed out; rebuilding inline"* (5×) | Index-build timeout sized from all `DEFAULT_CODE_EXTENSIONS` (not just `.py`); per-root single-flight guard stops concurrent orphaned rebuilds. |
| `victor init` → ollama timed out after 300s, template fallback | Adaptive per-request timeout (local models larger, `VICTOR_INIT_SYNTH_TIMEOUT` override), retry on timeout/connection, classified failure logging. |
| *"[provider-stream] Local runtime was unavailable for 68.3s"* on **cloud zai** | Reworded to attribute heartbeat overruns to local event-loop blocking (host-side GC/CPU), not the provider. |
| Agent repeated the same *"Let me drill into…"* narration many turns | Repetition detector force-completes on a single near-duplicate turn and no longer decays mid-spin, so oscillating loops converge. Decision logic extracted to a pure, unit-tested helper. |

## Tiers
- **Tier 1 — correctness:** graph availability gate, centrality SQL bindings, node resolution, polyglot index timeout, filename timeout, single-flight rebuild.
- **Tier 2 — resilience/UX:** init adaptive timeout + retry, honest stall signal, spin-breaking repetition.
- **Tier 3 — consolidation:** canonical `resolve_project_db_root()`, polyglot file-counting via shared `DEFAULT_CODE_EXTENSIONS`, subpath scoping for broad modes.

## Verification
- New: **66 targeted tests** across 6 new test files.
- Regression: **3462 + 70 + 168 passed** (core, framework, graph, code-search suites).
- `ruff` clean · **black 26.1.0** (CI pin, verified in an isolated venv) clean · `mypy` clean on all 6 modified modules · `make check-repo-hygiene` clean.
- Pre-existing unrelated: 4 failures in `tests/unit/core/test_stream_renderer.py` (UI rendering, not in this changeset).

## Notes
- `fix(init)` also carries pre-existing in-progress workspace changes to `init_synthesizer.py` (meta-commentary post-processing of synthesized output), bundled by author request.
- End-to-end against the live ProximaDB repo not run here (heavy/interactive); covered by unit + regression tests.
