### PR TITLE
fix: resolve deterministic CI-Tests failures (1 real bug + 5 stale tests)

### DIFF
--- a/tests/unit/agent/test_orchestrator_performance.py
+++ b/tests/unit/agent/test_orchestrator_performance.py
@@ -70,10 +70,16 @@ async def test_embedding_preloading_reduces_latency():
         )
         orchestrator_with_preload.tools.register(dummy_tool)
 
-        # Start the preload and wait for it to finish
+        # Start the preload and wait for it to finish.
         orchestrator_with_preload.start_embedding_preload()
-        # Give the event loop time to run the task
-        await asyncio.sleep(load_delay + 0.1)
+        # Await the actual preload task(s) deterministically rather than racing a
+        # fixed sleep — under CI scheduling jitter the background task may not
+        # complete within a fixed margin, causing select_semantic() to re-init
+        # and a spurious "called twice" failure.
+        for _task_attr in ("_embedding_preload_task", "_runtime_preload_task"):
+            _preload_task = getattr(orchestrator_with_preload, _task_attr, None)
+            if _preload_task is not None:
+                await _preload_task
 
         # select_semantic should NOT re-initialize (preload already did it)
         await orchestrator_with_preload.tool_selector.select_semantic("test message")

--- a/tests/unit/commands/test_init_command.py
+++ b/tests/unit/commands/test_init_command.py
@@ -131,8 +131,11 @@ def test_init_ccg_reports_project_graph_stats_without_name_error(tmp_path, monke
     fake_graph_store.stats.assert_awaited_once()
 
     rendered = output.getvalue()
-    assert "CCG index updated" in rendered
-    assert "12 total nodes, 34 total edges in database" in rendered
+    # The index-updated branch reports "Graph index updated" + a "N nodes, M
+    # edges in database" line (the legacy "CCG index updated" / "N total nodes"
+    # wording was deliberately retired — see init.py).
+    assert "Graph index updated" in rendered
+    assert "12 nodes, 34 edges in database" in rendered
     assert "CCG indexing skipped" not in rendered
 
 

--- a/tests/unit/commands/test_init_command.py
+++ b/tests/unit/commands/test_init_command.py
@@ -290,7 +290,9 @@ async def test_create_init_agent_uses_lightweight_profile_provider():
         "zai",
         base_url="https://api.z.ai/api/coding/paas/v4/",
         coding_plan=True,
-        timeout=120,
+        # Cloud providers get the 300s init-synthesis budget (_init_provider_timeout);
+        # local providers get 600s. The old flat 120s constant was retired.
+        timeout=300,
         max_retries=0,
     )
 

--- a/tests/unit/core/test_minimal_vertical_example_contract_surface.py
+++ b/tests/unit/core/test_minimal_vertical_example_contract_surface.py
@@ -39,9 +39,10 @@ def test_minimal_vertical_example_uses_contract_import_namespace() -> None:
 
     assert "from victor_contracts import PluginContext, VictorPlugin" in init_source
     assert "from victor_contracts.verticals.protocols.base import VerticalBase" in init_source
-    assert "from victor_contracts.verticals.protocols import ToolProvider, SafetyProvider" in (
-        init_source
-    )
+    # __init__ imports both protocols from the canonical namespace; tolerate
+    # single-line or parenthesized multi-line import formatting.
+    assert "from victor_contracts.verticals.protocols import" in init_source
+    assert "ToolProvider" in init_source and "SafetyProvider" in init_source
     assert "from victor_contracts.verticals.protocols import ToolProvider, SafetyProvider" in (
         protocols_source
     )

--- a/tests/unit/observability/test_debug_logger.py
+++ b/tests/unit/observability/test_debug_logger.py
@@ -331,8 +331,13 @@ class TestLogToolCall:
         assert debug_logger.stats.tool_calls_made == 2
 
     def test_truncates_long_args(self, debug_logger):
-        """Test long args are truncated."""
-        long_value = "a" * 100
+        """Long args are truncated to a size-prefixed head…tail preview.
+
+        ``_format_value`` renders ``(N chars): <first 60>...<last 30>`` for long
+        values, which only shortens inputs well above ~106 chars; use a clearly
+        long value so truncation is actually exercised.
+        """
+        long_value = "a" * 1000
         with patch.object(debug_logger.logger, "info") as mock_info:
             debug_logger.log_tool_call("test", {"long": long_value}, 1)
             call_str = mock_info.call_args[0][0]

--- a/tests/unit/tools/test_tool_executor_unit.py
+++ b/tests/unit/tools/test_tool_executor_unit.py
@@ -2274,8 +2274,12 @@ class TestFailedPathRedirects:
 class TestIntentBasedToolFilter:
     """Tests for Issue 4: intent-based tool filtering in _select_tools_for_turn."""
 
-    def test_read_only_intent_filters_write_tools(self):
-        """READ_ONLY intent should remove write/generation tools from the tool list."""
+    def test_read_only_intent_uses_permissive_tool_policy(self):
+        """READ_ONLY uses a permissive (empty) block-set.
+
+        Tools are no longer removed from the list by intent; safety is enforced
+        via the prompt guard instead (see INTENT_BLOCKED_TOOLS [PERMISSIVE]).
+        """
         from victor.agent.action_authorizer import INTENT_BLOCKED_TOOLS, ActionIntent
         from victor.tools.tool_names import get_canonical_name
 
@@ -2287,14 +2291,9 @@ class TestIntentBasedToolFilter:
             {"name": "execute_bash"},
         ]
         blocked = INTENT_BLOCKED_TOOLS[ActionIntent.READ_ONLY]
+        assert blocked == frozenset()  # permissive: nothing hard-blocked
         filtered = [t for t in tools if get_canonical_name(t.get("name", "")) not in blocked]
-
-        names = {t["name"] for t in filtered}
-        assert "write_file" not in names
-        assert "edit_files" not in names
-        assert "execute_bash" not in names
-        assert "read" in names
-        assert "code_search" in names
+        assert filtered == tools  # no tools removed
 
     def test_write_allowed_intent_no_filtering(self):
         """WRITE_ALLOWED intent should not filter any tools."""
@@ -2307,17 +2306,16 @@ class TestIntentBasedToolFilter:
 
         assert len(filtered) == len(tools)
 
-    def test_display_only_intent_filters_write_tools(self):
-        """DISPLAY_ONLY intent should remove write tools."""
+    def test_display_only_intent_uses_permissive_tool_policy(self):
+        """DISPLAY_ONLY uses a permissive (empty) block-set; safety via prompt guard."""
         from victor.agent.action_authorizer import INTENT_BLOCKED_TOOLS, ActionIntent
         from victor.tools.tool_names import get_canonical_name
 
         tools = [{"name": "write_file"}, {"name": "read"}, {"name": "ls"}]
         blocked = INTENT_BLOCKED_TOOLS[ActionIntent.DISPLAY_ONLY]
+        assert blocked == frozenset()  # permissive: nothing hard-blocked
         filtered = [t for t in tools if get_canonical_name(t.get("name", "")) not in blocked]
-
-        assert {"name": "write_file"} not in filtered
-        assert {"name": "read"} in filtered
+        assert filtered == tools  # no tools removed
 
     def test_invalid_intent_string_does_not_crash(self):
         """An unrecognised intent string should not raise, just skip filtering."""

--- a/victor/agent/tool_pipeline.py
+++ b/victor/agent/tool_pipeline.py
@@ -2900,9 +2900,12 @@ class ToolPipeline:
                 )
             else:
                 # Check if agent explicitly provided offset/limit in the original call
-                # (not just defaults from argument normalization)
-                explicit_offset = "offset" in raw_args
-                explicit_limit = "limit" in raw_args
+                # (not just defaults from argument normalization). ``raw_args`` may be
+                # None when a tool call arrives without an arguments object; treat that
+                # as "no explicit offset/limit" rather than crashing.
+                raw_args_map = raw_args if isinstance(raw_args, dict) else {}
+                explicit_offset = "offset" in raw_args_map
+                explicit_limit = "limit" in raw_args_map
                 follow_up_rewrite = (
                     self._select_follow_up_code_read_rewrite(
                         str(file_path),


### PR DESCRIPTION
Fixes the **deterministic** subset of the pre-existing CI-Tests failures tracked in #96 (the ones that fail in isolation, exposed once #97's timeout fix let shards complete). 6 commits — 1 real production bug, 5 stale tests.

## Real bug
- **`fix(tool-pipeline)`** — `_select_follow_up_code_read_rewrite` path did `"offset" in raw_args` / `"limit" in raw_args`, raising `TypeError: argument of type 'NoneType' is not iterable` when a tool call arrived with no arguments object. Guard a non-dict `raw_args` as having no explicit offset/limit. (`test_execute_tool_calls_none_arguments` correctly caught this.)

## Stale tests updated to match deliberate behavior
- **`test(observability)`** — `_format_value` truncates to a size-prefixed `head…tail` preview that only shortens inputs above ~106 chars; the 100-char fixture was too short. Use a 1000-char value.
- **`test(tools)`** — `INTENT_BLOCKED_TOOLS` is now all-empty (`[PERMISSIVE]` — rely on prompt guards, not tool removal). READ_ONLY/DISPLAY_ONLY filter tests assert the empty block-set / no-filtering behavior.
- **`test(contracts)`** — minimal-vertical example imports `ToolProvider/SafetyProvider` via a parenthesized multi-line statement; the guard asserted the single-line form. Check format-agnostically.
- **`test(init)` (CCG)** — init.py retired `"CCG index updated"` / `"N total nodes"` for `"Graph index updated"` / `"N nodes, M edges in database"`. Update the assertions.
- **`test(init)` (timeout)** — follow-up to #95: `_init_provider_timeout` gives cloud providers 300s (local 600s); this lightweight-profile test still asserted the retired flat 120s.

## Verification
- All 6 target tests pass; orchestrator + tool_pipeline regression: **387 passed** (production fix clean); ruff + black 26.1.0 clean on every commit.

## Not included (remain in #96)
- 5 order-dependent **pollution** flakes (pass in isolation, fail in full shard) — need per-leak bisection.
- `test_init_enriches_content_with_architecture_evidence` is a slow (>120s) real-enrichment test — not a CI failure (CI sets no per-test timeout), but a candidate for `@pytest.mark.slow` to cut shard time.
