### PR TITLE
refactor(providers): consolidate duplicated extraction helpers into openai_compat

### DIFF
--- a/tests/unit/providers/test_llamacpp_provider.py
+++ b/tests/unit/providers/test_llamacpp_provider.py
@@ -21,8 +21,6 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from victor.providers.llamacpp_provider import (
     LlamaCppProvider,
     _model_supports_tools,
-    _extract_thinking_content,
-    _extract_tool_calls_from_content,
     TOOL_CAPABLE_PATTERNS,
     DEFAULT_LLAMACPP_URLS,
 )
@@ -110,86 +108,6 @@ class TestModelSupportsTools:
         """Test base models without patterns don't support tools."""
         assert _model_supports_tools("gpt2.gguf") is False
         assert _model_supports_tools("phi-2") is False
-
-
-class TestExtractThinkingContent:
-    """Tests for _extract_thinking_content function."""
-
-    def test_extract_thinking(self):
-        """Test extracting thinking content."""
-        response = "<think>Let me analyze this...</think>Here is my answer."
-        thinking, content = _extract_thinking_content(response)
-        assert thinking == "Let me analyze this..."
-        assert content == "Here is my answer."
-
-    def test_extract_multiple_thinking_blocks(self):
-        """Test extracting multiple thinking blocks."""
-        response = "<think>First</think>Text<think>Second</think>More"
-        thinking, content = _extract_thinking_content(response)
-        assert "First" in thinking
-        assert "Second" in thinking
-        assert "Text" in content
-        assert "More" in content
-
-    def test_no_thinking_tags(self):
-        """Test content without thinking tags."""
-        response = "Just a normal response"
-        thinking, content = _extract_thinking_content(response)
-        assert thinking == ""
-        assert content == "Just a normal response"
-
-    def test_case_insensitive(self):
-        """Test case-insensitive tag matching."""
-        response = "<THINK>Thinking</THINK>Answer"
-        thinking, content = _extract_thinking_content(response)
-        assert thinking == "Thinking"
-        assert content == "Answer"
-
-
-class TestExtractToolCallsFromContent:
-    """Tests for _extract_tool_calls_from_content function."""
-
-    def test_extract_json_block(self):
-        """Test extracting tool call from JSON code block."""
-        content = '```json\n{"name": "read_file", "arguments": {"path": "test.py"}}\n```'
-        tool_calls, remaining = _extract_tool_calls_from_content(content)
-        assert len(tool_calls) == 1
-        assert tool_calls[0]["name"] == "read_file"
-        assert tool_calls[0]["arguments"]["path"] == "test.py"
-
-    def test_extract_tool_output_tags(self):
-        """Test extracting tool call from TOOL_OUTPUT tags."""
-        content = '<TOOL_OUTPUT>{"name": "search", "arguments": {"query": "test"}}</TOOL_OUTPUT>'
-        tool_calls, remaining = _extract_tool_calls_from_content(content)
-        assert len(tool_calls) == 1
-        assert tool_calls[0]["name"] == "search"
-
-    def test_extract_inline_json(self):
-        """Test extracting inline JSON tool call."""
-        content = '{"name": "list_files", "arguments": {"directory": "."}}'
-        tool_calls, remaining = _extract_tool_calls_from_content(content)
-        assert len(tool_calls) == 1
-        assert tool_calls[0]["name"] == "list_files"
-        assert remaining == ""
-
-    def test_no_tool_calls(self):
-        """Test content without tool calls."""
-        content = "This is just regular text without any tool calls."
-        tool_calls, remaining = _extract_tool_calls_from_content(content)
-        assert len(tool_calls) == 0
-        assert remaining == content
-
-    def test_invalid_json(self):
-        """Test handling of invalid JSON."""
-        content = "```json\n{invalid json}\n```"
-        tool_calls, remaining = _extract_tool_calls_from_content(content)
-        assert len(tool_calls) == 0
-
-    def test_json_without_name(self):
-        """Test JSON that doesn't have name field."""
-        content = '{"type": "object", "value": 42}'
-        tool_calls, remaining = _extract_tool_calls_from_content(content)
-        assert len(tool_calls) == 0
 
 
 # =============================================================================

--- a/tests/unit/providers/test_openai_compat.py
+++ b/tests/unit/providers/test_openai_compat.py
@@ -447,3 +447,91 @@ class TestFixOrphanedToolMessages:
         assert "tool_calls" in result[1]
         assert result[2]["role"] == "tool"
         assert result[2]["tool_call_id"] == "call_123"
+
+
+# Consolidated from per-provider duplicates (vLLM/llama.cpp) — the extraction
+# helpers now live in victor.providers.openai_compat.
+from victor.providers.openai_compat import (  # noqa: E402
+    extract_thinking_content,
+    extract_tool_calls_from_content,
+)
+
+
+class TestExtractThinkingContent:
+    """Tests for extract_thinking_content function."""
+
+    def test_extract_thinking(self):
+        """Test extracting thinking content."""
+        response = "<think>Let me think about this...</think>Here is my answer."
+        thinking, content = extract_thinking_content(response)
+        assert thinking == "Let me think about this..."
+        assert content == "Here is my answer."
+
+    def test_extract_multiple_thinking_blocks(self):
+        """Test extracting multiple thinking blocks."""
+        response = "<think>First thought</think>Text<think>Second thought</think>More text"
+        thinking, content = extract_thinking_content(response)
+        assert "First thought" in thinking
+        assert "Second thought" in thinking
+        assert "Text" in content
+        assert "More text" in content
+
+    def test_no_thinking_tags(self):
+        """Test content without thinking tags."""
+        response = "Just a normal response"
+        thinking, content = extract_thinking_content(response)
+        assert thinking == ""
+        assert content == "Just a normal response"
+
+    def test_case_insensitive(self):
+        """Test case-insensitive tag matching."""
+        response = "<THINK>Thinking</THINK>Answer"
+        thinking, content = extract_thinking_content(response)
+        assert thinking == "Thinking"
+        assert content == "Answer"
+
+
+class TestExtractToolCallsFromContent:
+    """Tests for extract_tool_calls_from_content function."""
+
+    def test_extract_json_block(self):
+        """Test extracting tool call from JSON code block."""
+        content = '```json\n{"name": "read_file", "arguments": {"path": "test.py"}}\n```'
+        tool_calls, remaining = extract_tool_calls_from_content(content)
+        assert len(tool_calls) == 1
+        assert tool_calls[0]["name"] == "read_file"
+        assert tool_calls[0]["arguments"]["path"] == "test.py"
+
+    def test_extract_tool_output_tags(self):
+        """Test extracting tool call from TOOL_OUTPUT tags."""
+        content = '<TOOL_OUTPUT>{"name": "search", "arguments": {"query": "test"}}</TOOL_OUTPUT>'
+        tool_calls, remaining = extract_tool_calls_from_content(content)
+        assert len(tool_calls) == 1
+        assert tool_calls[0]["name"] == "search"
+
+    def test_extract_inline_json(self):
+        """Test extracting inline JSON tool call."""
+        content = '{"name": "list_files", "arguments": {"directory": "."}}'
+        tool_calls, remaining = extract_tool_calls_from_content(content)
+        assert len(tool_calls) == 1
+        assert tool_calls[0]["name"] == "list_files"
+        assert remaining == ""
+
+    def test_no_tool_calls(self):
+        """Test content without tool calls."""
+        content = "This is just regular text without any tool calls."
+        tool_calls, remaining = extract_tool_calls_from_content(content)
+        assert len(tool_calls) == 0
+        assert remaining == content
+
+    def test_invalid_json(self):
+        """Test handling of invalid JSON."""
+        content = "```json\n{invalid json here}\n```"
+        tool_calls, remaining = extract_tool_calls_from_content(content)
+        assert len(tool_calls) == 0
+
+    def test_json_without_name(self):
+        """Test JSON that doesn't have name field."""
+        content = '{"type": "object", "value": 42}'
+        tool_calls, remaining = extract_tool_calls_from_content(content)
+        assert len(tool_calls) == 0

--- a/tests/unit/providers/test_vllm_provider.py
+++ b/tests/unit/providers/test_vllm_provider.py
@@ -22,8 +22,6 @@ from victor.providers.vllm_provider import (
     VLLMProvider,
     _model_supports_tools,
     _model_uses_thinking_tags,
-    _extract_thinking_content,
-    _extract_tool_calls_from_content,
     TOOL_CAPABLE_MODELS,
     THINKING_TAG_MODELS,
     DEFAULT_VLLM_URLS,
@@ -136,86 +134,6 @@ class TestModelUsesThinkingTags:
         """Test regular models don't use thinking tags."""
         assert _model_uses_thinking_tags("llama-3.1-8b") is False
         assert _model_uses_thinking_tags("gpt-4") is False
-
-
-class TestExtractThinkingContent:
-    """Tests for _extract_thinking_content function."""
-
-    def test_extract_thinking(self):
-        """Test extracting thinking content."""
-        response = "<think>Let me think about this...</think>Here is my answer."
-        thinking, content = _extract_thinking_content(response)
-        assert thinking == "Let me think about this..."
-        assert content == "Here is my answer."
-
-    def test_extract_multiple_thinking_blocks(self):
-        """Test extracting multiple thinking blocks."""
-        response = "<think>First thought</think>Text<think>Second thought</think>More text"
-        thinking, content = _extract_thinking_content(response)
-        assert "First thought" in thinking
-        assert "Second thought" in thinking
-        assert "Text" in content
-        assert "More text" in content
-
-    def test_no_thinking_tags(self):
-        """Test content without thinking tags."""
-        response = "Just a normal response"
-        thinking, content = _extract_thinking_content(response)
-        assert thinking == ""
-        assert content == "Just a normal response"
-
-    def test_case_insensitive(self):
-        """Test case-insensitive tag matching."""
-        response = "<THINK>Thinking</THINK>Answer"
-        thinking, content = _extract_thinking_content(response)
-        assert thinking == "Thinking"
-        assert content == "Answer"
-
-
-class TestExtractToolCallsFromContent:
-    """Tests for _extract_tool_calls_from_content function."""
-
-    def test_extract_json_block(self):
-        """Test extracting tool call from JSON code block."""
-        content = '```json\n{"name": "read_file", "arguments": {"path": "test.py"}}\n```'
-        tool_calls, remaining = _extract_tool_calls_from_content(content)
-        assert len(tool_calls) == 1
-        assert tool_calls[0]["name"] == "read_file"
-        assert tool_calls[0]["arguments"]["path"] == "test.py"
-
-    def test_extract_tool_output_tags(self):
-        """Test extracting tool call from TOOL_OUTPUT tags."""
-        content = '<TOOL_OUTPUT>{"name": "search", "arguments": {"query": "test"}}</TOOL_OUTPUT>'
-        tool_calls, remaining = _extract_tool_calls_from_content(content)
-        assert len(tool_calls) == 1
-        assert tool_calls[0]["name"] == "search"
-
-    def test_extract_inline_json(self):
-        """Test extracting inline JSON tool call."""
-        content = '{"name": "list_files", "arguments": {"directory": "."}}'
-        tool_calls, remaining = _extract_tool_calls_from_content(content)
-        assert len(tool_calls) == 1
-        assert tool_calls[0]["name"] == "list_files"
-        assert remaining == ""
-
-    def test_no_tool_calls(self):
-        """Test content without tool calls."""
-        content = "This is just regular text without any tool calls."
-        tool_calls, remaining = _extract_tool_calls_from_content(content)
-        assert len(tool_calls) == 0
-        assert remaining == content
-
-    def test_invalid_json(self):
-        """Test handling of invalid JSON."""
-        content = "```json\n{invalid json here}\n```"
-        tool_calls, remaining = _extract_tool_calls_from_content(content)
-        assert len(tool_calls) == 0
-
-    def test_json_without_name(self):
-        """Test JSON that doesn't have name field."""
-        content = '{"type": "object", "value": 42}'
-        tool_calls, remaining = _extract_tool_calls_from_content(content)
-        assert len(tool_calls) == 0
 
 
 # =============================================================================

--- a/victor/providers/llamacpp_provider.py
+++ b/victor/providers/llamacpp_provider.py
@@ -61,6 +61,8 @@ from victor.providers.base import (
 )
 from victor.providers.logging import ProviderLogger
 from victor.providers.openai_compat import (
+    extract_thinking_content as _extract_thinking_content,
+    extract_tool_calls_from_content as _extract_tool_calls_from_content,
     convert_messages_to_openai_format,
     convert_tools_to_openai_format,
     parse_openai_tool_calls,
@@ -97,121 +99,6 @@ def _model_supports_tools(model: str) -> bool:
     """
     model_lower = model.lower()
     return any(pattern in model_lower for pattern in TOOL_CAPABLE_PATTERNS)
-
-
-def _extract_thinking_content(response: str) -> Tuple[str, str]:
-    """Extract thinking content from response.
-
-    Args:
-        response: Raw response text
-
-    Returns:
-        Tuple of (thinking_content, main_content)
-    """
-    think_pattern = r"<think>(.*?)</think>"
-    matches = re.findall(think_pattern, response, re.DOTALL | re.IGNORECASE)
-    thinking = "\n".join(matches) if matches else ""
-    content = re.sub(think_pattern, "", response, flags=re.DOTALL | re.IGNORECASE).strip()
-    return (thinking, content)
-
-
-def _extract_tool_calls_from_content(content: str) -> Tuple[List[Dict[str, Any]], str]:
-    """Extract tool calls from content when server doesn't parse them.
-
-    Handles cases where model outputs tool calls as JSON text.
-    Common formats:
-    - ```json\n{...}\n```
-    - <TOOL_OUTPUT>{...}</TOOL_OUTPUT>
-    - {"name": "...", "arguments": {...}}
-
-    Note: Must distinguish from task plan JSON which also has "name" but different structure.
-    Tool calls have "arguments" which are dict objects with tool-specific structure.
-
-    Args:
-        content: Response content that may contain tool calls
-
-    Returns:
-        Tuple of (parsed_tool_calls, remaining_content)
-    """
-    tool_calls = []
-    remaining = content
-
-    # Planning keywords to avoid false positives
-    planning_keywords = {"complexity", "steps", "desc", "duration"}
-
-    # Pattern 1: JSON code block with tool call
-    json_block_pattern = r"```json\s*\n?\s*(\{[^`]*\"name\"\s*:\s*\"[^\"]+\"[^`]*\})\s*\n?```"
-    matches = re.findall(json_block_pattern, content, re.DOTALL)
-    for match in matches:
-        try:
-            data = json.loads(match)
-            if "name" in data:
-                arguments = data.get("arguments", {})
-                # Only treat as tool call if arguments is a dict and doesn't look like planning JSON
-                if isinstance(arguments, dict) and not any(
-                    key in arguments for key in planning_keywords
-                ):
-                    tool_calls.append(
-                        {
-                            "id": f"fallback_{len(tool_calls)}",
-                            "name": data.get("name", ""),
-                            "arguments": arguments,
-                        }
-                    )
-                    remaining = remaining.replace(f"```json\n{match}\n```", "").strip()
-                    remaining = remaining.replace(f"```json{match}```", "").strip()
-        except json.JSONDecodeError:
-            pass
-
-    # Pattern 2: <TOOL_OUTPUT> tags
-    tool_output_pattern = r"<TOOL_OUTPUT>\s*(\{.*?\})\s*</TOOL_OUTPUT>"
-    matches = re.findall(tool_output_pattern, content, re.DOTALL)
-    for match in matches:
-        try:
-            data = json.loads(match)
-            if "name" in data:
-                arguments = data.get("arguments", {})
-                # Only treat as tool call if arguments is a dict and doesn't look like planning JSON
-                if isinstance(arguments, dict) and not any(
-                    key in arguments for key in planning_keywords
-                ):
-                    tool_calls.append(
-                        {
-                            "id": f"fallback_{len(tool_calls)}",
-                            "name": data.get("name", ""),
-                            "arguments": arguments,
-                        }
-                    )
-                    remaining = re.sub(
-                        r"<TOOL_OUTPUT>\s*" + re.escape(match) + r"\s*</TOOL_OUTPUT>",
-                        "",
-                        remaining,
-                    )
-        except json.JSONDecodeError:
-            pass
-
-    # Pattern 3: Inline JSON (for simple cases)
-    if not tool_calls and content.strip().startswith("{") and "name" in content:
-        try:
-            data = json.loads(content.strip())
-            if "name" in data:
-                arguments = data.get("arguments", {})
-                # Only treat as tool call if arguments is a dict and doesn't look like planning JSON
-                if isinstance(arguments, dict) and not any(
-                    key in arguments for key in planning_keywords
-                ):
-                    tool_calls.append(
-                        {
-                            "id": "fallback_0",
-                            "name": data.get("name", ""),
-                            "arguments": arguments,
-                        }
-                    )
-                    remaining = ""
-        except json.JSONDecodeError:
-            pass
-
-    return tool_calls, remaining.strip()
 
 
 class LlamaCppProvider(BaseProvider):

--- a/victor/providers/lmstudio_provider.py
+++ b/victor/providers/lmstudio_provider.py
@@ -36,6 +36,9 @@ from typing import Any, AsyncIterator, Dict, List, Optional, Tuple, Union
 
 import httpx
 
+from victor.providers.openai_compat import (
+    extract_thinking_content as _extract_thinking_content,
+)
 from victor.providers.base import (
     BaseProvider,
     CompletionResponse,
@@ -83,28 +86,6 @@ def _model_supports_tools(model: str) -> bool:
     """Check if a model supports native tool calling."""
     model_lower = model.lower()
     return any(pattern in model_lower for pattern in TOOL_CAPABLE_MODELS)
-
-
-def _extract_thinking_content(response: str) -> Tuple[str, str]:
-    """Extract <think>...</think> tags from response.
-
-    Args:
-        response: Raw response text
-
-    Returns:
-        Tuple of (thinking_content, main_content)
-    """
-    if not response:
-        return ("", "")
-
-    # Match <think>...</think> tags (case insensitive, multiline)
-    think_pattern = r"<think>(.*?)</think>"
-    matches = re.findall(think_pattern, response, re.DOTALL | re.IGNORECASE)
-
-    thinking = "\n".join(matches) if matches else ""
-    content = re.sub(think_pattern, "", response, flags=re.DOTALL | re.IGNORECASE).strip()
-
-    return (thinking, content)
 
 
 class LMStudioProvider(BaseProvider):

--- a/victor/providers/openai_compat.py
+++ b/victor/providers/openai_compat.py
@@ -22,9 +22,10 @@ These utilities help reduce code duplication across provider implementations.
 
 import json
 import logging
+import re
 import uuid
 from contextvars import ContextVar
-from typing import Any, Dict, List, Mapping, Optional
+from typing import Any, Dict, List, Mapping, Optional, Tuple
 
 import httpx
 
@@ -628,3 +629,119 @@ def accumulate_tool_call_delta(
             accumulated[idx]["name"] = func["name"]
         if "arguments" in func:
             accumulated[idx]["arguments"] += func["arguments"]
+
+
+def extract_thinking_content(response: str) -> Tuple[str, str]:
+    """Extract ``<think>...</think>`` reasoning blocks from a response.
+
+    Shared across OpenAI-compatible local providers (vLLM, llama.cpp, LM Studio,
+    …) that may surface a model's chain-of-thought inline. Returns the thinking
+    text and the response with the think blocks stripped.
+
+    Args:
+        response: Raw response text.
+
+    Returns:
+        Tuple of ``(thinking_content, main_content)``.
+    """
+    if not response:
+        return ("", "")
+
+    think_pattern = r"<think>(.*?)</think>"
+    matches = re.findall(think_pattern, response, re.DOTALL | re.IGNORECASE)
+    thinking = "\n".join(matches) if matches else ""
+    content = re.sub(think_pattern, "", response, flags=re.DOTALL | re.IGNORECASE).strip()
+    return (thinking, content)
+
+
+def extract_tool_calls_from_content(content: str) -> Tuple[List[Dict[str, Any]], str]:
+    """Extract tool calls embedded as JSON text when the server didn't parse them.
+
+    Shared fallback for OpenAI-compatible local providers (e.g. vLLM not started
+    with ``--enable-auto-tool-choice``). Recognizes three shapes:
+    ``` ```json {...}``` ```, ``<TOOL_OUTPUT>{...}</TOOL_OUTPUT>``, and a bare
+    inline ``{"name": ..., "arguments": {...}}``. Planning-style JSON (which also
+    has ``name`` but different structure) is rejected via keyword heuristics.
+
+    Args:
+        content: Response content that may contain tool calls.
+
+    Returns:
+        Tuple of ``(parsed_tool_calls, remaining_content)``.
+    """
+    tool_calls: List[Dict[str, Any]] = []
+    remaining = content
+
+    # Planning keywords to avoid false positives
+    planning_keywords = {"complexity", "steps", "desc", "duration"}
+
+    # Pattern 1: JSON code block with tool call
+    json_block_pattern = r"```json\s*\n?\s*(\{[^`]*\"name\"\s*:\s*\"[^\"]+\"[^`]*\})\s*\n?```"
+    matches = re.findall(json_block_pattern, content, re.DOTALL)
+    for match in matches:
+        try:
+            data = json.loads(match)
+            if "name" in data:
+                arguments = data.get("arguments", {})
+                if isinstance(arguments, dict) and not any(
+                    key in arguments for key in planning_keywords
+                ):
+                    tool_calls.append(
+                        {
+                            "id": f"fallback_{len(tool_calls)}",
+                            "name": data.get("name", ""),
+                            "arguments": arguments,
+                        }
+                    )
+                    remaining = remaining.replace(f"```json\n{match}\n```", "").strip()
+                    remaining = remaining.replace(f"```json{match}```", "").strip()
+        except json.JSONDecodeError:
+            pass
+
+    # Pattern 2: <TOOL_OUTPUT> tags
+    tool_output_pattern = r"<TOOL_OUTPUT>\s*(\{.*?\})\s*</TOOL_OUTPUT>"
+    matches = re.findall(tool_output_pattern, content, re.DOTALL)
+    for match in matches:
+        try:
+            data = json.loads(match)
+            if "name" in data:
+                arguments = data.get("arguments", {})
+                if isinstance(arguments, dict) and not any(
+                    key in arguments for key in planning_keywords
+                ):
+                    tool_calls.append(
+                        {
+                            "id": f"fallback_{len(tool_calls)}",
+                            "name": data.get("name", ""),
+                            "arguments": arguments,
+                        }
+                    )
+                    remaining = re.sub(
+                        r"<TOOL_OUTPUT>\s*" + re.escape(match) + r"\s*</TOOL_OUTPUT>",
+                        "",
+                        remaining,
+                    )
+        except json.JSONDecodeError:
+            pass
+
+    # Pattern 3: Inline JSON (for simple cases)
+    if not tool_calls and content.strip().startswith("{") and "name" in content:
+        try:
+            data = json.loads(content.strip())
+            if "name" in data:
+                arguments = data.get("arguments", {})
+                if isinstance(arguments, dict) and not any(
+                    key in arguments for key in planning_keywords
+                ):
+                    tool_calls.append(
+                        {
+                            "id": "fallback_0",
+                            "name": data.get("name", ""),
+                            "arguments": arguments,
+                        }
+                    )
+                    remaining = ""
+        except json.JSONDecodeError:
+            pass
+
+    return tool_calls, remaining.strip()

--- a/victor/providers/vllm_provider.py
+++ b/victor/providers/vllm_provider.py
@@ -60,6 +60,8 @@ from victor.providers.base import (
 )
 from victor.providers.logging import ProviderLogger
 from victor.providers.openai_compat import (
+    extract_thinking_content as _extract_thinking_content,
+    extract_tool_calls_from_content as _extract_tool_calls_from_content,
     convert_messages_to_openai_format,
     convert_tools_to_openai_format,
     parse_openai_tool_calls,
@@ -119,122 +121,6 @@ def _model_uses_thinking_tags(model: str) -> bool:
     """
     model_lower = model.lower()
     return any(pattern in model_lower for pattern in THINKING_TAG_MODELS)
-
-
-def _extract_thinking_content(response: str) -> Tuple[str, str]:
-    """Extract thinking content from response.
-
-    Args:
-        response: Raw response text
-
-    Returns:
-        Tuple of (thinking_content, main_content)
-    """
-    think_pattern = r"<think>(.*?)</think>"
-    matches = re.findall(think_pattern, response, re.DOTALL | re.IGNORECASE)
-    thinking = "\n".join(matches) if matches else ""
-    content = re.sub(think_pattern, "", response, flags=re.DOTALL | re.IGNORECASE).strip()
-    return (thinking, content)
-
-
-def _extract_tool_calls_from_content(content: str) -> Tuple[List[Dict[str, Any]], str]:
-    """Extract tool calls from content when server doesn't parse them.
-
-    Handles cases where vLLM wasn't started with --enable-auto-tool-choice.
-    Models may output tool calls as JSON in various formats:
-    - ```json\n{...}\n```
-    - <TOOL_OUTPUT>{...}</TOOL_OUTPUT>
-    - {"name": "...", "arguments": {...}}
-
-    Note: Must distinguish from task plan JSON which also has "name" but different structure.
-    Tool calls have "arguments" which are dict objects with tool-specific structure.
-
-    Args:
-        content: Response content that may contain tool calls
-
-    Returns:
-        Tuple of (parsed_tool_calls, remaining_content)
-    """
-    tool_calls = []
-    remaining = content
-
-    # Planning keywords to avoid false positives
-    planning_keywords = {"complexity", "steps", "desc", "duration"}
-
-    # Pattern 1: JSON code block with tool call
-    json_block_pattern = r"```json\s*\n?\s*(\{[^`]*\"name\"\s*:\s*\"[^\"]+\"[^`]*\})\s*\n?```"
-    matches = re.findall(json_block_pattern, content, re.DOTALL)
-    for match in matches:
-        try:
-            data = json.loads(match)
-            if "name" in data:
-                arguments = data.get("arguments", {})
-                # Only treat as tool call if arguments is a dict and doesn't look like planning JSON
-                if isinstance(arguments, dict) and not any(
-                    key in arguments for key in planning_keywords
-                ):
-                    tool_calls.append(
-                        {
-                            "id": f"fallback_{len(tool_calls)}",
-                            "name": data.get("name", ""),
-                            "arguments": arguments,
-                        }
-                    )
-                    remaining = remaining.replace(f"```json\n{match}\n```", "").strip()
-                    remaining = remaining.replace(f"```json{match}```", "").strip()
-        except json.JSONDecodeError:
-            pass
-
-    # Pattern 2: <TOOL_OUTPUT> tags
-    tool_output_pattern = r"<TOOL_OUTPUT>\s*(\{.*?\})\s*</TOOL_OUTPUT>"
-    matches = re.findall(tool_output_pattern, content, re.DOTALL)
-    for match in matches:
-        try:
-            data = json.loads(match)
-            if "name" in data:
-                arguments = data.get("arguments", {})
-                # Only treat as tool call if arguments is a dict and doesn't look like planning JSON
-                if isinstance(arguments, dict) and not any(
-                    key in arguments for key in planning_keywords
-                ):
-                    tool_calls.append(
-                        {
-                            "id": f"fallback_{len(tool_calls)}",
-                            "name": data.get("name", ""),
-                            "arguments": arguments,
-                        }
-                    )
-                    remaining = re.sub(
-                        r"<TOOL_OUTPUT>\s*" + re.escape(match) + r"\s*</TOOL_OUTPUT>",
-                        "",
-                        remaining,
-                    )
-        except json.JSONDecodeError:
-            pass
-
-    # Pattern 3: Inline JSON (for simple cases)
-    if not tool_calls and content.strip().startswith("{") and "name" in content:
-        try:
-            # Try to parse the entire content as JSON
-            data = json.loads(content.strip())
-            if "name" in data:
-                arguments = data.get("arguments", {})
-                # Only treat as tool call if arguments is a dict and doesn't look like planning JSON
-                if isinstance(arguments, dict) and not any(
-                    key in arguments for key in planning_keywords
-                ):
-                    tool_calls.append(
-                        {
-                            "id": "fallback_0",
-                            "name": data.get("name", ""),
-                            "arguments": arguments,
-                        }
-                    )
-                    remaining = ""
-        except json.JSONDecodeError:
-            pass
-
-    return tool_calls, remaining.strip()
 
 
 class VLLMProvider(BaseProvider):


### PR DESCRIPTION
Consolidates the source-level duplication surfaced by the test-dedup pass (#100): `_extract_thinking_content` and `_extract_tool_calls_from_content` were copy-pasted across local OpenAI-compatible providers.

## Change
- **`victor/providers/openai_compat.py`** gains canonical `extract_thinking_content` and `extract_tool_calls_from_content` (the guarded thinking variant + the full tool-call parser).
- **vllm, llamacpp, lmstudio** drop their local copies and alias the canonical functions (keeping the private `_extract_*` names used internally and imported by tests).
- **mlx** keeps its intentionally simpler tool-call parser (a genuinely different implementation — left untouched).
- The duplicated `TestExtractThinkingContent` / `TestExtractToolCallsFromContent` classes (in both `test_vllm_provider.py` and `test_llamacpp_provider.py`) are consolidated into **`test_openai_compat.py`** (one copy, testing the canonical functions); the now-unused imports are cleaned up.

## Why safe
- **Behavioral equivalence verified** against the original vLLM/llama.cpp/LM Studio implementations across thinking-tag and tool-call edge cases (the lmstudio `if not response` guard is a no-op since `re.findall('')` already returns `[]`).
- Full providers suite: **1480 passed, 21 skipped, 0 failed**.
- ruff + black-26.1.0 + mypy(strict) clean on all changed modules.

Net effect: ~4 provider copies of these helpers collapse to one shared implementation, and the duplicated extraction tests collapse from two provider files into `test_openai_compat.py`.
