### PR TITLE
ci(tests): raise per-shard timeout 60→75 to absorb runner variance

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -45,7 +45,7 @@ jobs:
     # 12-way split lands shards near 40-45 min and many were cancelled at the
     # old 45-min cap. Raise headroom while the fixture-speed/duration-balancing
     # work is tracked separately. See the CI-Tests stabilization issue.
-    timeout-minutes: 60
+    timeout-minutes: 75
     needs: []  # No dependencies - run in parallel with ci-fast
     env:
       PYTHONPATH: ${{ github.workspace }}


### PR DESCRIPTION
Final piece of the CI-Tests timeout fix. After #102's `.test_durations` balanced the shard workload, a validation run on develop showed:

| | before (count-split) | after (durations) |
|---|---|---|
| success shards | 30 | **41** |
| cancelled (timeout) | 5 | **1** |
| shard runtime | unbalanced | min 32 / avg 41 / max 56 min |

The one remaining cancellation is **GitHub shared-runner speed variance** (~1.5–2×) pushing the heaviest balanced shard past 60 min — not a workload imbalance. Raising the cap to 75 min absorbs that (avg 41, max 56 → ~19 min headroom) while still bounding genuinely-stuck jobs.

Together with #102 this closes the CI-Tests **timeout** thread; the residual failures are the ~5 environment-specific pollution flakes tracked in #96.